### PR TITLE
83 make it possible to dump articles from database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ DB_POOL_MIN_SIZE="2"
 DB_POOL_MAX_SIZE="10"
 
 # Embedding settings
-USE_GPU="false"  # Set to true to enable GPU acceleration for embedding generation
 GPU_BATCH_SIZE="256"  # Batch size for GPU processing
 
 # CPU embedding settings

--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,6 @@ DB_POOL_MAX_SIZE="10"
 # Embedding settings
 USE_GPU="false"  # Set to true to enable GPU acceleration for embedding generation
 GPU_BATCH_SIZE="256"  # Batch size for GPU processing
-GPU_MEMORY_LIMIT_GB="40"  # GPU memory limit per device in GB
-GPU_DEVICE_IDS="0,1,2,3"  # Comma-separated GPU device IDs (e.g., '0,1,2,3')
 
 # CPU embedding settings
 CPU_BATCH_SIZE="16"  # Batch size for CPU inference

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,16 @@ DB_PASSWORD="changeme"
 DB_POOL_MIN_SIZE="2"
 DB_POOL_MAX_SIZE="10"
 
+# Embedding settings
+USE_GPU="false"  # Set to true to enable GPU acceleration for embedding generation
+GPU_BATCH_SIZE="256"  # Batch size for GPU processing
+GPU_MEMORY_LIMIT_GB="40"  # GPU memory limit per device in GB
+GPU_DEVICE_IDS="0,1,2,3"  # Comma-separated GPU device IDs (e.g., '0,1,2,3')
+
+# CPU embedding settings
+CPU_BATCH_SIZE="16"  # Batch size for CPU inference
+CPU_NUM_THREADS="4"  # Number of threads for CPU inference
+
 # Sitemap settings
 SITEMAP_RATE_LIMIT="5"  # Max concurrent JSON requests (reduce if hitting rate limits)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for the Lex DB project
 
-.PHONY: install run static-type-check lint lint-check test pr help
+.PHONY: install install-dev generate-openapi-schema run-dev run static-type-check lint lint-check test pr help
 
 # Default target
 default: help
@@ -8,10 +8,6 @@ default: help
 install:
 	@echo "--- 🚀 Installing project dependencies ---"
 	uv sync
-
-install-gpu:
-	@echo "--- 🚀 Installing GPU-accelerated dependencies ---"
-	uv sync --extra gpu
 
 install-dev:
 	@echo "--- 🚀 Installing development dependencies ---"
@@ -22,11 +18,11 @@ generate-openapi-schema:
 	uv run generate_openapi.py main:app --out openapi/openapi.yaml
 	@echo "OpenAPI schema generated successfully."
 
-run-dev: install-dev generate-openapi-schema
+run-dev: generate-openapi-schema
 	@echo "--- ▶️ Running the application in dev mode ---"
 	uv run main.py
 
-run: install generate-openapi-schema
+run: generate-openapi-schema
 	@echo "--- ▶️ Running the application ---"
 	uv run main.py
 
@@ -57,7 +53,7 @@ help:
 	@echo "Makefile for the Lex DB project"
 	@echo ""
 	@echo "Available commands:"
-	@echo "  make install             Install project dependencies using uv sync"
+	@echo "  make install             Install project dependencies (CPU version)"
 	@echo "  make run                 Run the FastAPI application using 'uv run main.py'"
 	@echo "  make static-type-check   Run static type checking with mypy on the current directory"
 	@echo "  make lint                Format code with Ruff and apply lint fixes"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ install:
 	@echo "--- 🚀 Installing project dependencies ---"
 	uv sync
 
+install-gpu:
+	@echo "--- 🚀 Installing GPU-accelerated dependencies ---"
+	uv sync --extra gpu
+
 install-dev:
 	@echo "--- 🚀 Installing development dependencies ---"
 	uv sync --dev

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ cd lex-db
 make install
 ```
 
+#### GPU vs CPU Installation
+
+By default, ONNX models with are used with CPU for broader compatibility.
+
+**For GPU acceleration** (NVIDIA CUDA):
+To enable GPU acceleration, set in your `.env`:
+```env
+USE_GPU=true
+```
+
+Note: GPU mode uses the transformers library directly for inference, while CPU mode uses ONNX Runtime with INT8 quantization for optimal performance.
+
 ### 3. Set up PostgreSQL database
 Ensure PostgreSQL is installed and the pgvector extension is available:
 ```bash

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -319,6 +319,8 @@ components:
       enum:
       - intfloat/multilingual-e5-small
       - intfloat/multilingual-e5-large
+      - jinaai/jina-embeddings-v5-text-small
+      - jinaai/jina-embeddings-v5-text-nano
       - text-embedding-ada-002
       - text-embedding-3-small
       - text-embedding-3-large

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
     "markdownify>=1.2.2",
 ]
 
+[project.optional-dependencies]
+gpu = [
+    "onnxruntime-gpu>=1.16.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "types-pyyaml>=6.0.12.20250516",
     "tiktoken>=0.9.0",
     "sentence-splitter>=1.4",
-    "optimum[onnxruntime]>=2.0.0",
     "psycopg[binary,pool]>=3.3.2",
     "pgvector>=0.4.2",
     "sqlalchemy>=2.0.45",
@@ -32,11 +31,10 @@ dependencies = [
     "httpx>=0.28.1",
     "pytest-asyncio>=1.3.0",
     "markdownify>=1.2.2",
-]
-
-[project.optional-dependencies]
-gpu = [
-    "onnxruntime-gpu>=1.16.0",
+    "transformers>=4.57.0",
+    "torch>=2.8.0",
+    "optimum[onnxruntime]>=2.1.0",
+    "peft>=0.18.1",
 ]
 
 [build-system]

--- a/src/lex_db/config.py
+++ b/src/lex_db/config.py
@@ -32,7 +32,6 @@ class Settings(BaseSettings):
     DB_POOL_MAX_SIZE: int = 10
 
     # Embedding model settings
-    USE_GPU: bool = False  # Set to True to enable GPU acceleration for local models
     GPU_BATCH_SIZE: int = 64  # Batch size for GPU inference
 
     # CPU embedding settings

--- a/src/lex_db/config.py
+++ b/src/lex_db/config.py
@@ -34,8 +34,6 @@ class Settings(BaseSettings):
     # Embedding model settings
     USE_GPU: bool = False  # Set to True to enable GPU acceleration for local models
     GPU_BATCH_SIZE: int = 64  # Batch size for GPU inference
-    GPU_MEMORY_LIMIT_GB: int = 40  # GPU memory limit per device in GB
-    GPU_DEVICE_IDS: str = "0,1,2,3"  # Comma-separated GPU device IDs (e.g., "0,1,2,3")
 
     # CPU embedding settings
     CPU_BATCH_SIZE: int = 16  # Batch size for CPU inference

--- a/src/lex_db/config.py
+++ b/src/lex_db/config.py
@@ -31,6 +31,16 @@ class Settings(BaseSettings):
     DB_POOL_MIN_SIZE: int = 2
     DB_POOL_MAX_SIZE: int = 10
 
+    # Embedding model settings
+    USE_GPU: bool = False  # Set to True to enable GPU acceleration for local models
+    GPU_BATCH_SIZE: int = 64  # Batch size for GPU inference
+    GPU_MEMORY_LIMIT_GB: int = 40  # GPU memory limit per device in GB
+    GPU_DEVICE_IDS: str = "0,1,2,3"  # Comma-separated GPU device IDs (e.g., "0,1,2,3")
+
+    # CPU embedding settings
+    CPU_BATCH_SIZE: int = 16  # Batch size for CPU inference
+    CPU_NUM_THREADS: int = 4  # Number of threads for CPU inference
+
     # Sitemap settings
     SITEMAP_BASE_URL: str = "https://lex.dk/.sitemap"
     SITEMAP_REQUEST_TIMEOUT: int = 30

--- a/src/lex_db/embeddings.py
+++ b/src/lex_db/embeddings.py
@@ -2,18 +2,22 @@
 
 from enum import Enum
 import os
+from typing import Protocol, runtime_checkable
 from optimum.onnxruntime import ORTModelForFeatureExtraction, ORTQuantizer  # type: ignore
 from optimum.onnxruntime.configuration import AutoQuantizationConfig  # type: ignore
 import onnxruntime as ort  # type: ignore
 import torch
 from torch.nn.functional import normalize
-from transformers.models.auto.tokenization_auto import AutoTokenizer
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+from transformers.modeling_utils import PreTrainedModel  # type: ignore
+from transformers.models.auto.tokenization_auto import AutoTokenizer  # type: ignore
+from transformers.models.auto.modeling_auto import AutoModel  # type: ignore
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase  # type: ignore
 import numpy as np
 import time
 from collections import deque
 from threading import Lock
 import tiktoken
+from sentence_transformers import SentenceTransformer
 from lex_db.utils import get_logger
 from lex_db.config import get_settings
 from pathlib import Path
@@ -41,27 +45,26 @@ class TextType(str, Enum):
 
 def get_embedding_dimensions(model_choice: EmbeddingModel) -> int:
     """Get the dimension of embeddings for a given model."""
-    if model_choice == EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL:
-        return 384
-    elif model_choice == EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE:
-        return 1024
-    elif model_choice == EmbeddingModel.OPENAI_ADA_002:
-        return 1536
-    elif model_choice == EmbeddingModel.OPENAI_SMALL_003:
-        return 1536
-    elif model_choice == EmbeddingModel.OPENAI_LARGE_003:
-        return 3072
-    elif model_choice == EmbeddingModel.JINA_V5_SMALL:
-        return 1024
-    elif model_choice == EmbeddingModel.JINA_V5_NANO:
-        return 768
-    elif model_choice == EmbeddingModel.MOCK_MODEL:
-        return 4  # A small, fixed dimension for testing
-    else:
+    dimensions = {
+        EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL: 384,
+        EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE: 1024,
+        EmbeddingModel.OPENAI_ADA_002: 1536,
+        EmbeddingModel.OPENAI_SMALL_003: 1536,
+        EmbeddingModel.OPENAI_LARGE_003: 3072,
+        EmbeddingModel.JINA_V5_SMALL: 1024,
+        EmbeddingModel.JINA_V5_NANO: 768,
+        EmbeddingModel.MOCK_MODEL: 4,
+    }
+    if model_choice not in dimensions:
         raise ValueError(f"Unknown model: {model_choice}")
+    return dimensions[model_choice]
 
 
-# Rate limiting for OpenAI API
+# =============================================================================
+# Rate Limiting for OpenAI API
+# =============================================================================
+
+
 class OpenAIRateLimiter:
     """Rate limiter for OpenAI API calls."""
 
@@ -127,8 +130,500 @@ class OpenAIRateLimiter:
 # Global rate limiter instance
 _openai_rate_limiter = OpenAIRateLimiter()
 
-# Module-level cache for loaded models
-_model_cache: dict[EmbeddingModel, dict] = {}
+
+# =============================================================================
+# Model Handler Pattern
+# =============================================================================
+
+
+@runtime_checkable
+class EmbeddingModelHandler(Protocol):
+    """Protocol defining the interface for model-specific embedding operations."""
+
+    def load_model(self, use_gpu: bool) -> tuple:
+        """Load model and tokenizer. Returns (model, tokenizer, use_gpu)."""
+        ...
+
+    def compute_embeddings(
+        self,
+        model: PreTrainedModel | ORTModelForFeatureExtraction | SentenceTransformer,
+        tokenizer: PreTrainedTokenizerBase,
+        texts: list[tuple[str, TextType]],
+    ) -> list[list[float]]:
+        """Compute embeddings for texts."""
+        ...
+
+
+class E5ModelHandler:
+    """Handler for multilingual E5 models (small and large).
+
+    E5 models use:
+    - "query: " prefix for queries
+    - "passage: " prefix for passages
+    - Mean pooling with attention mask
+    - INT8 quantized ONNX for CPU inference
+    """
+
+    def __init__(self, model_choice: EmbeddingModel):
+        self.model_choice = model_choice
+        self.model_name = model_choice.value
+
+    def _format_texts(self, texts: list[tuple[str, TextType]]) -> list[str]:
+        """Format texts with E5-specific prefixes."""
+        return [f"{text_type.value}: {text}" for text, text_type in texts]
+
+    def load_model(self, use_gpu: bool) -> tuple:
+        """Load E5 model for GPU or CPU inference."""
+        if use_gpu:
+            return self._load_for_gpu()
+        else:
+            return self._load_for_cpu()
+
+    def _load_for_gpu(self) -> tuple:
+        """Load transformers model for GPU inference."""
+        device = "cuda:0"
+        logger.info(f"Loading E5 model for GPU: {self.model_name}")
+
+        model = AutoModel.from_pretrained(
+            self.model_name,
+            trust_remote_code=True,
+        ).to(device)
+        model.eval()
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.model_name,
+            trust_remote_code=True,
+        )
+
+        logger.info(f"E5 model loaded on {device}")
+        return model, tokenizer, True
+
+    def _load_for_cpu(self) -> tuple:
+        """Load ONNX model optimized for CPU inference with INT8 quantization."""
+        settings = get_settings()
+        num_threads = settings.CPU_NUM_THREADS
+
+        sess_options = self._create_session_options(num_threads)
+        cache_dir = get_onnx_cache_dir()
+        model_cache_path = cache_dir / self.model_name.replace("/", "_")
+        quantized_model_path = (
+            cache_dir / f"{self.model_name.replace('/', '_')}_quantized"
+        )
+
+        # Check if quantized model exists
+        if (
+            quantized_model_path.exists()
+            and (quantized_model_path / "model_quantized.onnx").exists()
+        ):
+            logger.info(
+                f"Loading quantized E5 ONNX model from cache: {quantized_model_path}"
+            )
+            model = ORTModelForFeatureExtraction.from_pretrained(
+                quantized_model_path,
+                file_name="model_quantized.onnx",
+                provider="CPUExecutionProvider",
+                session_options=sess_options,
+                provider_options={
+                    "CPUExecutionProvider": {
+                        "arena_extend_strategy": "kSameAsRequested"
+                    }
+                },
+            )
+            tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+            return model, tokenizer, False
+
+        # Check if regular ONNX model exists
+        if model_cache_path.exists() and (model_cache_path / "model.onnx").exists():
+            logger.info(f"Loading E5 ONNX model from cache: {model_cache_path}")
+            model = ORTModelForFeatureExtraction.from_pretrained(
+                model_cache_path,
+                provider="CPUExecutionProvider",
+                session_options=sess_options,
+                provider_options={
+                    "CPUExecutionProvider": {
+                        "arena_extend_strategy": "kSameAsRequested"
+                    }
+                },
+            )
+            tokenizer = AutoTokenizer.from_pretrained(model_cache_path)
+
+            # Quantize and save
+            model, tokenizer = self._quantize_model(
+                model, tokenizer, quantized_model_path
+            )
+            return model, tokenizer, False
+
+        # Export and quantize
+        logger.info(f"Exporting E5 ONNX model to: {model_cache_path}")
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            self.model_name,
+            export=True,
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {"arena_extend_strategy": "kSameAsRequested"}
+            },
+        )
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+
+        model.save_pretrained(model_cache_path)
+        tokenizer.save_pretrained(model_cache_path)
+        logger.info(f"E5 ONNX model saved to cache: {model_cache_path}")
+
+        # Quantize
+        model, tokenizer = self._quantize_model(model, tokenizer, quantized_model_path)
+        return model, tokenizer, False
+
+    def _create_session_options(self, num_threads: int) -> ort.SessionOptions:
+        """Create optimized ONNX Runtime session options."""
+        sess_options = ort.SessionOptions()
+        sess_options.graph_optimization_level = (
+            ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        )
+        sess_options.intra_op_num_threads = num_threads
+        sess_options.inter_op_num_threads = num_threads
+        sess_options.execution_mode = ort.ExecutionMode.ORT_PARALLEL
+        sess_options.enable_cpu_mem_arena = True
+        sess_options.enable_mem_pattern = True
+        sess_options.enable_mem_reuse = True
+        return sess_options
+
+    def _quantize_model(
+        self,
+        model: ORTModelForFeatureExtraction,
+        tokenizer: PreTrainedTokenizerBase,
+        quantized_model_path: Path,
+    ) -> tuple:
+        """Quantize model to INT8 and save."""
+        logger.info("Quantizing E5 model to INT8 for faster inference...")
+        quantizer = ORTQuantizer.from_pretrained(model)
+        qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=False)
+
+        quantized_model_path.mkdir(parents=True, exist_ok=True)
+        quantizer.quantize(
+            save_dir=quantized_model_path,
+            quantization_config=qconfig,
+            file_suffix="quantized",
+        )
+        tokenizer.save_pretrained(quantized_model_path)
+
+        # Reload quantized model
+        sess_options = self._create_session_options(get_settings().CPU_NUM_THREADS)
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            quantized_model_path,
+            file_name="model_quantized.onnx",
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {"arena_extend_strategy": "kSameAsRequested"}
+            },
+        )
+        logger.info(f"Quantized E5 model saved to: {quantized_model_path}")
+        return model, tokenizer
+
+    def compute_embeddings(
+        self,
+        model: PreTrainedModel | ORTModelForFeatureExtraction | SentenceTransformer,
+        tokenizer: PreTrainedTokenizerBase,
+        texts: list[tuple[str, TextType]],
+    ) -> list[list[float]]:
+        """Compute embeddings using mean pooling."""
+
+        formatted_texts = self._format_texts(texts)
+
+        if isinstance(model, PreTrainedModel):
+            return self._compute_embeddings_gpu(model, tokenizer, formatted_texts)
+        elif isinstance(model, ORTModelForFeatureExtraction):
+            return self._compute_embeddings_onnx(model, tokenizer, formatted_texts)
+        else:
+            raise ValueError(f"Unsupported model type: {type(model)}")
+
+    def _compute_embeddings_onnx(
+        self,
+        model: ORTModelForFeatureExtraction,
+        tokenizer: PreTrainedTokenizerBase,
+        texts: list[str],
+    ) -> list[list[float]]:
+        """Compute mean-pooled normalized embeddings using ONNX."""
+        encoded = tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            return_token_type_ids=False,
+            return_attention_mask=True,
+        )
+
+        with torch.no_grad():
+            outputs = model(**encoded)
+            token_embeddings = outputs.last_hidden_state
+            attention_mask = encoded["attention_mask"]
+
+            # Mean pooling with attention mask
+            input_mask_expanded = (
+                attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            )
+            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+            sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+            embeddings = sum_embeddings / sum_mask
+
+            # L2 normalize
+            embeddings = normalize(embeddings, p=2, dim=1)
+
+        return list(embeddings.numpy().tolist())
+
+    def _compute_embeddings_gpu(
+        self,
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizerBase,
+        texts: list[str],
+        device: str = "cuda:0",
+    ) -> list[list[float]]:
+        """Compute mean-pooled normalized embeddings using transformers on GPU."""
+        encoded = tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            return_token_type_ids=False,
+            return_attention_mask=True,
+        )
+
+        # Move inputs to GPU
+        encoded = {k: v.to(device) for k, v in encoded.items()}
+
+        with torch.no_grad():
+            outputs = model(**encoded)
+            token_embeddings = outputs.last_hidden_state
+            attention_mask = encoded["attention_mask"]
+
+            # Mean pooling with attention mask
+            input_mask_expanded = (
+                attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            )
+            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+            sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+            embeddings = sum_embeddings / sum_mask
+
+            # L2 normalize
+            embeddings = normalize(embeddings, p=2, dim=1)
+
+        return list(embeddings.cpu().numpy().tolist())
+
+
+class JinaV5ModelHandler:
+    """Handler for Jina v5 models (small and nano).
+
+    Jina v5 models use:
+    - "Query: " prefix for queries (retrieval task)
+    - "Document: " prefix for passages (retrieval task)
+    - Last-token pooling (critical for Jina v5)
+    - Specialized ONNX models from 'onnx' subfolder for CPU
+    - model.encode() API with task="retrieval" for GPU
+    """
+
+    def __init__(self, model_choice: EmbeddingModel):
+        self.model_choice = model_choice
+        self.model_name = model_choice.value
+        # Jina provides specialized retrieval models for ONNX
+        self.onnx_model_name = f"{model_choice.value}-retrieval"
+
+    def _format_texts(self, texts: list[tuple[str, TextType]]) -> list[str]:
+        """Format texts with Jina-specific prefixes for retrieval task."""
+        formatted = []
+        for text, text_type in texts:
+            if text_type == TextType.QUERY:
+                formatted.append(f"Query: {text}")
+            else:
+                formatted.append(f"Document: {text}")
+        return formatted
+
+    def load_model(self, use_gpu: bool) -> tuple:
+        """Load Jina v5 model for GPU or CPU inference."""
+        if use_gpu:
+            return self._load_for_gpu()
+        else:
+            return self._load_for_cpu()
+
+    def _load_for_gpu(self) -> tuple:
+        """Load SentenceTransformer model for GPU inference."""
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        logger.info(f"Loading Jina v5 model for GPU: {self.model_name}")
+
+        model_kwargs: dict = {"trust_remote_code": True}
+
+        model = SentenceTransformer(
+            self.model_name,
+            trust_remote_code=True,
+            device=device,
+            model_kwargs=model_kwargs,
+        )
+
+        # SentenceTransformer doesn't need a separate tokenizer
+        tokenizer = None
+
+        logger.info(f"Jina v5 model loaded on {device}")
+        return model, tokenizer, True
+
+    def _load_for_cpu(self) -> tuple:
+        """Load specialized Jina ONNX model for CPU inference."""
+        settings = get_settings()
+        num_threads = settings.CPU_NUM_THREADS
+
+        sess_options = self._create_session_options(num_threads)
+        cache_dir = get_onnx_cache_dir()
+        # Use separate cache path for Jina retrieval models
+        model_cache_path = cache_dir / self.onnx_model_name.replace("/", "_")
+
+        # Jina provides pre-optimized ONNX models in the 'onnx' subfolder
+        if model_cache_path.exists() and (model_cache_path / "model.onnx").exists():
+            logger.info(f"Loading Jina v5 ONNX model from cache: {model_cache_path}")
+        else:
+            logger.info(f"Downloading Jina v5 ONNX model: {self.onnx_model_name}")
+
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            self.onnx_model_name,
+            subfolder="onnx",
+            file_name="model.onnx",
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {"arena_extend_strategy": "kSameAsRequested"}
+            },
+            trust_remote_code=True,
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.onnx_model_name,
+            trust_remote_code=True,
+        )
+
+        # Cache the model for faster subsequent loads
+        if not (model_cache_path / "model.onnx").exists():
+            model_cache_path.mkdir(parents=True, exist_ok=True)
+            model.save_pretrained(model_cache_path)
+            tokenizer.save_pretrained(model_cache_path)
+            logger.info(f"Jina v5 ONNX model cached to: {model_cache_path}")
+
+        return model, tokenizer, False
+
+    def _create_session_options(self, num_threads: int) -> ort.SessionOptions:
+        """Create optimized ONNX Runtime session options."""
+        sess_options = ort.SessionOptions()
+        sess_options.graph_optimization_level = (
+            ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        )
+        sess_options.intra_op_num_threads = num_threads
+        sess_options.inter_op_num_threads = num_threads
+        sess_options.execution_mode = ort.ExecutionMode.ORT_PARALLEL
+        sess_options.enable_cpu_mem_arena = True
+        sess_options.enable_mem_pattern = True
+        sess_options.enable_mem_reuse = True
+        return sess_options
+
+    def compute_embeddings(
+        self,
+        model: PreTrainedModel | ORTModelForFeatureExtraction | SentenceTransformer,
+        tokenizer: PreTrainedTokenizerBase,
+        texts: list[tuple[str, TextType]],
+    ) -> list[list[float]]:
+        """Compute embeddings using model-specific method."""
+        if isinstance(model, SentenceTransformer):
+            return self._compute_embeddings_gpu(model, texts)
+        elif isinstance(model, ORTModelForFeatureExtraction):
+            return self._compute_embeddings_onnx(
+                model, tokenizer, self._format_texts(texts)
+            )
+        else:
+            raise ValueError(f"Unsupported model type: {type(model)}")
+
+    def _compute_embeddings_onnx(
+        self,
+        model: ORTModelForFeatureExtraction,
+        tokenizer: PreTrainedTokenizerBase,
+        texts: list[str],
+    ) -> list[list[float]]:
+        """Compute embeddings using last-token pooling (critical for Jina v5)."""
+        encoded = tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            return_token_type_ids=False,
+            return_attention_mask=True,
+        )
+
+        with torch.no_grad():
+            outputs = model(**encoded)
+            last_hidden_state = outputs.last_hidden_state
+
+            # Last-token pooling: take the hidden state of the last non-padding token
+            sequence_lengths = encoded["attention_mask"].sum(dim=1) - 1
+            embeddings = last_hidden_state[
+                torch.arange(last_hidden_state.size(0)), sequence_lengths
+            ]
+
+            # L2 normalize
+            embeddings = normalize(embeddings, p=2, dim=1)
+
+        return list(embeddings.numpy().tolist())
+
+    def _compute_embeddings_gpu(
+        self,
+        model: SentenceTransformer,
+        texts: list[tuple[str, TextType]],
+    ) -> list[list[float]]:
+        """Compute embeddings using SentenceTransformer's encode() API.
+
+        SentenceTransformer handles pooling internally.
+        We need to separate queries and documents to use the correct prompt_name.
+        """
+
+        queries = [text for text, text_type in texts if text_type == TextType.QUERY]
+        documents = [text for text, text_type in texts if text_type == TextType.PASSAGE]
+
+        all_embeddings: list[list[float]] = []
+        # Encode queries
+        if queries:
+            query_embeddings = model.encode(  # type: ignore
+                sentences=queries,
+                task="retrieval",
+                prompt_name="query",
+            )
+            all_embeddings.extend(query_embeddings)
+
+        # Encode documents
+        if documents:
+            doc_embeddings = model.encode(  # type: ignore
+                sentences=documents,
+                task="retrieval",
+                prompt_name="document",
+            )
+            all_embeddings.extend(doc_embeddings)
+
+        return all_embeddings
+
+
+# =============================================================================
+# Handler Registry
+# =============================================================================
+
+
+def get_handler(model_choice: EmbeddingModel) -> EmbeddingModelHandler:
+    """Get the appropriate handler for a model choice."""
+    if model_choice in (
+        EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL,
+        EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE,
+    ):
+        return E5ModelHandler(model_choice)
+    elif model_choice in (EmbeddingModel.JINA_V5_SMALL, EmbeddingModel.JINA_V5_NANO):
+        return JinaV5ModelHandler(model_choice)
+    else:
+        raise ValueError(f"No handler for model: {model_choice}")
+
+
+# =============================================================================
+# Model Cache and Loading
+# =============================================================================
 
 
 def get_onnx_cache_dir() -> Path:
@@ -138,276 +633,55 @@ def get_onnx_cache_dir() -> Path:
     return cache_dir
 
 
-def get_local_embedding_model(model_choice: EmbeddingModel) -> dict:
-    """Get a cached ONNX embedding model instance.
+# Module-level cache for loaded models
+_model_cache: dict[EmbeddingModel, dict] = {}
 
-    Automatically uses GPU if available and USE_GPU=True in settings.
-    Falls back to CPU-optimized quantized model otherwise.
+
+def get_local_embedding_model(model_choice: EmbeddingModel) -> dict:
+    """Get a cached embedding model instance.
+
+    Uses handlers to load models with appropriate settings for GPU or CPU inference.
     """
     if model_choice not in _model_cache:
-        if model_choice not in (
-            EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE,
-            EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL,
-            EmbeddingModel.JINA_V5_NANO,
-            EmbeddingModel.JINA_V5_SMALL,
-        ):
-            raise ValueError(f"Local model not supported: {model_choice}")
+        handler = get_handler(model_choice)
 
-        model_name = model_choice.value
         settings = get_settings()
         use_gpu = settings.USE_GPU
-
-        # Define cache directory for this specific model
-        # Use separate cache paths for GPU vs CPU to avoid loading wrong model variant
-        cache_dir = get_onnx_cache_dir()
-        model_cache_path = (
-            cache_dir / f"{model_name.replace('/', '_')}{'_gpu' if use_gpu else ''}"
-        )
-        quantized_model_path = cache_dir / f"{model_name.replace('/', '_')}_quantized"
 
         # Check GPU availability
         if use_gpu:
             if torch.cuda.is_available():
-                gpu_count = torch.cuda.device_count()
-                gpu_name = torch.cuda.get_device_name(0) if gpu_count > 0 else "Unknown"
-                logger.info(
-                    f"GPU acceleration enabled. Found {gpu_count} GPU(s): {gpu_name}"
-                )
+                gpu_name = torch.cuda.get_device_name(0)
+                logger.info(f"GPU acceleration enabled. Using: {gpu_name}")
             else:
                 logger.warning(
                     "USE_GPU=True but CUDA is not available. Falling back to CPU."
                 )
                 use_gpu = False
-                # Update cache path for CPU fallback
-                model_cache_path = cache_dir / model_name.replace("/", "_")
 
-        logger.info(f"Loading ONNX model: {model_name} (GPU: {use_gpu})")
-
-        if use_gpu:
-            # GPU path: Load model without quantization for better GPU performance
-            device_ids = [int(d.strip()) for d in settings.GPU_DEVICE_IDS.split(",")]
-            logger.info(f"Using GPU devices: {device_ids}")
-
-            # Load one model instance per GPU for parallel processing
-            models_per_gpu = []
-            for device_id in device_ids:
-                model, tokenizer = _load_model_for_gpu(
-                    model_name, model_cache_path, device_id
-                )
-                models_per_gpu.append((model, tokenizer, device_id))
-
-            # Use first model/tokenizer as primary (for single-GPU fallback)
-            model, tokenizer, _ = models_per_gpu[0]
-        else:
-            # CPU path: Use quantized model for faster CPU inference
-            model, tokenizer = _load_model_for_cpu(
-                model_name, model_cache_path, quantized_model_path
-            )
-            models_per_gpu = None
+        model, tokenizer, actual_use_gpu = handler.load_model(use_gpu)
 
         _model_cache[model_choice] = {
             "model": model,
             "tokenizer": tokenizer,
-            "use_gpu": use_gpu,
-            "models_per_gpu": models_per_gpu,
+            "use_gpu": actual_use_gpu,
+            "handler": handler,
         }
 
-        logger.info(f"ONNX model loaded successfully (GPU: {use_gpu})")
+        logger.info(f"Model loaded successfully (GPU: {actual_use_gpu})")
 
     return _model_cache[model_choice]
 
 
-def _load_model_for_gpu(
-    model_name: str, model_cache_path: Path, device_id: int = 0
-) -> tuple:
-    """Load ONNX model optimized for GPU inference.
-
-    GPU inference works best with non-quantized FP32 models.
-
-    Args:
-        model_name: HuggingFace model name
-        model_cache_path: Path to cache directory
-        device_id: GPU device ID to use (default: 0)
-    """
-    settings = get_settings()
-    gpu_mem_limit = (
-        settings.GPU_MEMORY_LIMIT_GB * 1024 * 1024 * 1024
-    )  # Convert GB to bytes
-
-    provider_options = {
-        "device_id": device_id,
-        "arena_extend_strategy": "kNextPowerOfTwo",
-        "gpu_mem_limit": gpu_mem_limit,
-        "cudnn_conv_algo_search": "EXHAUSTIVE",
-    }
-
-    # Check if model exists in cache
-    if model_cache_path.exists() and (model_cache_path / "model.onnx").exists():
-        logger.info(
-            f"Loading ONNX model from cache: {model_cache_path} (GPU {device_id})"
-        )
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            model_cache_path,
-            provider="CUDAExecutionProvider",
-            provider_options=provider_options,
-        )
-        tokenizer = AutoTokenizer.from_pretrained(model_cache_path)
-    else:
-        logger.info(
-            f"Exporting and saving ONNX model to: {model_cache_path} (GPU {device_id})"
-        )
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            model_name,
-            export=True,
-            provider="CUDAExecutionProvider",
-            provider_options=provider_options,
-        )
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
-
-        # Save the model and tokenizer to disk
-        model_cache_path.mkdir(parents=True, exist_ok=True)
-        model.save_pretrained(model_cache_path)
-        tokenizer.save_pretrained(model_cache_path)
-        logger.info(f"ONNX model saved to cache: {model_cache_path}")
-
-    return model, tokenizer
-
-
-def _load_model_for_cpu(
-    model_name: str, model_cache_path: Path, quantized_model_path: Path
-) -> tuple:
-    """Load ONNX model optimized for CPU inference with INT8 quantization."""
-    settings = get_settings()
-    num_threads = settings.CPU_NUM_THREADS
-
-    sess_options = ort.SessionOptions()
-    sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
-    sess_options.intra_op_num_threads = num_threads
-    sess_options.inter_op_num_threads = num_threads
-    sess_options.execution_mode = ort.ExecutionMode.ORT_PARALLEL
-
-    # Enable additional optimizations
-    sess_options.enable_cpu_mem_arena = True
-    sess_options.enable_mem_pattern = True
-    sess_options.enable_mem_reuse = True
-
-    # Check if quantized model exists
-    if (
-        quantized_model_path.exists()
-        and (quantized_model_path / "model_quantized.onnx").exists()
-    ):
-        logger.info(f"Loading quantized ONNX model from cache: {quantized_model_path}")
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            quantized_model_path,
-            file_name="model_quantized.onnx",
-            provider="CPUExecutionProvider",
-            session_options=sess_options,
-            provider_options={
-                "CPUExecutionProvider": {
-                    "arena_extend_strategy": "kSameAsRequested",
-                }
-            },
-        )
-        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
-    # Check if regular ONNX model exists
-    elif model_cache_path.exists() and (model_cache_path / "model.onnx").exists():
-        logger.info(f"Loading ONNX model from cache: {model_cache_path}")
-        logger.info("Quantizing model to INT8 for faster inference...")
-
-        # Load the model first
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            model_cache_path,
-            provider="CPUExecutionProvider",
-            session_options=sess_options,
-            provider_options={
-                "CPUExecutionProvider": {
-                    "arena_extend_strategy": "kSameAsRequested",
-                }
-            },
-        )
-        tokenizer = AutoTokenizer.from_pretrained(model_cache_path)
-
-        # Quantize the model
-        quantizer = ORTQuantizer.from_pretrained(model)
-        qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=False)
-
-        # Save quantized model
-        quantized_model_path.mkdir(parents=True, exist_ok=True)
-        quantizer.quantize(
-            save_dir=quantized_model_path,
-            quantization_config=qconfig,
-            file_suffix="quantized",
-        )
-        tokenizer.save_pretrained(quantized_model_path)
-
-        # Reload the quantized model
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            quantized_model_path,
-            file_name="model_quantized.onnx",
-            provider="CPUExecutionProvider",
-            session_options=sess_options,
-            provider_options={
-                "CPUExecutionProvider": {
-                    "arena_extend_strategy": "kSameAsRequested",
-                }
-            },
-        )
-        logger.info(f"Quantized model saved to: {quantized_model_path}")
-    else:
-        logger.info(f"Exporting and saving ONNX model to: {model_cache_path}")
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            model_name,
-            export=True,
-            provider="CPUExecutionProvider",
-            session_options=sess_options,
-            provider_options={
-                "CPUExecutionProvider": {
-                    "arena_extend_strategy": "kSameAsRequested",
-                }
-            },
-        )
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
-
-        # Save the model and tokenizer to disk
-        model.save_pretrained(model_cache_path)
-        tokenizer.save_pretrained(model_cache_path)
-        logger.info(f"ONNX model saved to cache: {model_cache_path}")
-
-        # Quantize the newly exported model
-        logger.info("Quantizing model to INT8 for faster inference...")
-        quantizer = ORTQuantizer.from_pretrained(model)
-        qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=False)
-
-        quantized_model_path.mkdir(parents=True, exist_ok=True)
-        quantizer.quantize(
-            save_dir=quantized_model_path,
-            quantization_config=qconfig,
-            file_suffix="quantized",
-        )
-        tokenizer.save_pretrained(quantized_model_path)
-
-        # Reload the quantized model
-        model = ORTModelForFeatureExtraction.from_pretrained(
-            quantized_model_path,
-            file_name="model_quantized.onnx",
-            provider="CPUExecutionProvider",
-            session_options=sess_options,
-            provider_options={
-                "CPUExecutionProvider": {
-                    "arena_extend_strategy": "kSameAsRequested",
-                }
-            },
-        )
-        logger.info(f"Quantized model saved to: {quantized_model_path}")
-
-    return model, tokenizer
+# =============================================================================
+# Batching Utilities
+# =============================================================================
 
 
 def create_optimal_request_batches(
     texts: list[str], max_tokens_per_batch: int = 8000
 ) -> list[list[str]]:
     """Create batches that don't exceed the token limit."""
-
     tokenizer = tiktoken.get_encoding("cl100k_base")
 
     batches = []
@@ -440,141 +714,9 @@ def create_optimal_request_batches(
     return batches
 
 
-def create_text_batches(texts: list[str], batch_size: int = 32) -> list[list[str]]:
-    """Create batches of texts for parallel processing."""
-    return [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
-
-
-def _compute_embeddings(
-    model: ORTModelForFeatureExtraction,
-    tokenizer: PreTrainedTokenizerBase,
-    texts: list[str],
-    device_id: int | None = None,
-) -> list[list[float]]:
-    """Compute mean-pooled normalized embeddings for a batch of texts."""
-
-    encoded = tokenizer(
-        texts,
-        padding=True,
-        truncation=True,
-        return_tensors="pt",
-        return_token_type_ids=False,
-        return_attention_mask=True,
-    )
-
-    # Move tensors to GPU if specified
-    if device_id is not None:
-        encoded = {k: v.cuda(device_id) for k, v in encoded.items()}
-
-    with torch.no_grad():
-        outputs = model(**encoded)
-        token_embeddings = outputs.last_hidden_state
-        attention_mask = encoded["attention_mask"]
-
-        # Mean pooling with attention mask
-        input_mask_expanded = (
-            attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-        )
-        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
-        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
-        embeddings = sum_embeddings / sum_mask
-
-        # L2 normalize
-        embeddings = normalize(embeddings, p=2, dim=1)
-
-    return list(embeddings.cpu().numpy().tolist())
-
-
-def _generate_embeddings_single_device(
-    texts: list[tuple[str, TextType]],
-    model: ORTModelForFeatureExtraction,
-    tokenizer: PreTrainedTokenizerBase,
-    use_gpu: bool,
-    batch_size: int,
-) -> list[list[float]]:
-    """Generate embeddings using a single device (CPU or single GPU)."""
-    all_embeddings = []
-    device_id = 0 if use_gpu else None
-    total_batches = (len(texts) + batch_size - 1) // batch_size
-
-    for i in range(0, len(texts), batch_size):
-        batch_texts = texts[i : i + batch_size]
-        formatted_texts = [f"{text[1].value}: {text[0]}" for text in batch_texts]
-
-        embeddings = _compute_embeddings(model, tokenizer, formatted_texts, device_id)
-        all_embeddings.extend(embeddings)
-
-        if total_batches > 1:
-            logger.debug(f"Processed batch {i // batch_size + 1}/{total_batches}")
-
-    return all_embeddings
-
-
-def _generate_embeddings_multi_gpu(
-    texts: list[tuple[str, TextType]],
-    models_per_gpu: list[
-        tuple[ORTModelForFeatureExtraction, PreTrainedTokenizerBase, int]
-    ],
-    tokenizer: PreTrainedTokenizerBase,
-    batch_size: int,
-) -> list[list[float]]:
-    """Generate embeddings using multiple GPUs in parallel."""
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    num_gpus = len(models_per_gpu)
-    logger.info(f"Processing {len(texts)} texts across {num_gpus} GPUs")
-
-    # Split texts into chunks for each GPU
-    chunk_size = (len(texts) + num_gpus - 1) // num_gpus
-    chunks = [texts[i : i + chunk_size] for i in range(0, len(texts), chunk_size)]
-
-    # Pad with empty lists to match GPU count
-    chunks.extend([[] for _ in range(num_gpus - len(chunks))])
-
-    all_embeddings: list[list[list[float]]] = [[] for _ in range(len(chunks))]
-
-    def process_chunk(
-        chunk_idx: int, chunk: list, model_tokenizer_device: tuple
-    ) -> tuple[int, list[list[float]]]:
-        """Process a chunk of texts on a specific GPU."""
-        model, _, device_id = model_tokenizer_device
-
-        if not chunk:
-            return chunk_idx, []
-
-        chunk_embeddings = []
-        total_batches = (len(chunk) + batch_size - 1) // batch_size
-
-        for i in range(0, len(chunk), batch_size):
-            batch_texts = chunk[i : i + batch_size]
-            formatted_texts = [f"{text[1].value}: {text[0]}" for text in batch_texts]
-
-            embeddings = _compute_embeddings(
-                model, tokenizer, formatted_texts, device_id
-            )
-            chunk_embeddings.extend(embeddings)
-
-            if total_batches > 1:
-                logger.debug(
-                    f"GPU {device_id}: Processed batch {i // batch_size + 1}/{total_batches}"
-                )
-
-        return chunk_idx, chunk_embeddings
-
-    # Process chunks in parallel across GPUs
-    with ThreadPoolExecutor(max_workers=num_gpus) as executor:
-        futures = [
-            executor.submit(process_chunk, idx, chunk, mtd)
-            for idx, (chunk, mtd) in enumerate(zip(chunks, models_per_gpu))
-        ]
-        for future in as_completed(futures):
-            chunk_idx, chunk_embeddings = future.result()
-            all_embeddings[chunk_idx] = chunk_embeddings
-
-    # Flatten results in order
-    result = [emb for chunk_embs in all_embeddings for emb in chunk_embs]
-    logger.info(f"Multi-GPU processing complete: {len(result)} embeddings generated")
-    return result
+# =============================================================================
+# Main Embedding Generation
+# =============================================================================
 
 
 def generate_embeddings(
@@ -593,17 +735,18 @@ def generate_embeddings(
             f"Please filter empty strings before calling generate_embeddings()"
         )
 
-    if model_choice == EmbeddingModel.MOCK_MODEL:  # Add this block
+    # Handle mock model
+    if model_choice == EmbeddingModel.MOCK_MODEL:
         logger.debug(f"Generating MOCK embeddings for {len(texts)} texts")
-        # Return a list of random dummy embeddings for testing
         return [
             np.random.random_sample(
                 get_embedding_dimensions(EmbeddingModel.MOCK_MODEL)
             ).tolist()
-            for t in texts
+            for _ in texts
         ]
 
-    elif model_choice in (
+    # Handle local models (E5 and Jina)
+    if model_choice in (
         EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE,
         EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL,
         EmbeddingModel.JINA_V5_SMALL,
@@ -612,27 +755,30 @@ def generate_embeddings(
         model_data = get_local_embedding_model(model_choice)
         model = model_data["model"]
         tokenizer = model_data["tokenizer"]
-        use_gpu = model_data.get("use_gpu", False)
-        models_per_gpu = model_data.get("models_per_gpu")
+        use_gpu = model_data["use_gpu"]
+        handler = model_data["handler"]
 
         # Use larger batch size for GPU, smaller for CPU
         settings = get_settings()
         batch_size = settings.GPU_BATCH_SIZE if use_gpu else settings.CPU_BATCH_SIZE
 
-        # Check if we have multiple GPUs for parallel processing
-        if use_gpu and models_per_gpu and len(models_per_gpu) > 1:
-            # Multi-GPU parallel processing
-            all_embeddings = _generate_embeddings_multi_gpu(
-                texts, models_per_gpu, tokenizer, batch_size
-            )
-        else:
-            # Single GPU or CPU processing
-            all_embeddings = _generate_embeddings_single_device(
-                texts, model, tokenizer, use_gpu, batch_size
-            )
+        all_embeddings = []
+        total_batches = (len(texts) + batch_size - 1) // batch_size
+
+        for i in range(0, len(texts), batch_size):
+            batch_texts = texts[i : i + batch_size]
+
+            # Compute embeddings using handler
+            embeddings = handler.compute_embeddings(model, tokenizer, batch_texts)
+
+            all_embeddings.extend(embeddings)
+
+            if total_batches > 1:
+                logger.debug(f"Processed batch {i // batch_size + 1}/{total_batches}")
 
         return all_embeddings
 
+    # Handle OpenAI models
     elif model_choice in [
         EmbeddingModel.OPENAI_ADA_002,
         EmbeddingModel.OPENAI_SMALL_003,
@@ -672,19 +818,20 @@ def generate_embeddings(
                     logger.error(f"Error in batch {batch_idx}: {str(e)}")
                     return batch_idx, None
 
-            max_workers = min(32, len(batches) + 4)  # Don't over-provision
+            max_workers = min(32, len(batches) + 4)
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = [
                     executor.submit(process_batch, (i, batch))
                     for i, batch in enumerate(batches)
                 ]
                 for future in as_completed(futures):
-                    batch_idx, result = future.result()  # type: ignore
+                    batch_idx, result = future.result()
                     if result is not None:
                         all_results[batch_idx] = result
+
             # Flatten results in correct order
             all_embeddings = []
-            for result in all_results:  # type: ignore
+            for result in all_results:
                 if result is not None:
                     all_embeddings.extend(result)
 
@@ -696,5 +843,6 @@ def generate_embeddings(
             raise ImportError("OpenAI package not installed. Install with 'uv sync'.")
         except Exception as e:
             raise ValueError(f"Error generating OpenAI embeddings: {str(e)}")
+
     else:
         raise ValueError(f"Unsupported embedding model: {model_choice}")

--- a/src/lex_db/embeddings.py
+++ b/src/lex_db/embeddings.py
@@ -8,13 +8,14 @@ import onnxruntime as ort  # type: ignore
 import torch
 from torch.nn.functional import normalize
 from transformers.models.auto.tokenization_auto import AutoTokenizer
-from typing import List, Optional, Tuple
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 import numpy as np
 import time
 from collections import deque
 from threading import Lock
 import tiktoken
 from lex_db.utils import get_logger
+from lex_db.config import get_settings
 from pathlib import Path
 
 logger = get_logger()
@@ -25,10 +26,17 @@ class EmbeddingModel(str, Enum):
 
     LOCAL_MULTILINGUAL_E5_SMALL = "intfloat/multilingual-e5-small"
     LOCAL_MULTILINGUAL_E5_LARGE = "intfloat/multilingual-e5-large"
+    JINA_V5_SMALL = "jinaai/jina-embeddings-v5-text-small"
+    JINA_V5_NANO = "jinaai/jina-embeddings-v5-text-nano"
     OPENAI_ADA_002 = "text-embedding-ada-002"
     OPENAI_SMALL_003 = "text-embedding-3-small"
     OPENAI_LARGE_003 = "text-embedding-3-large"
     MOCK_MODEL = "mock_model"
+
+
+class TextType(str, Enum):
+    QUERY = "query"
+    PASSAGE = "passage"
 
 
 def get_embedding_dimensions(model_choice: EmbeddingModel) -> int:
@@ -43,6 +51,10 @@ def get_embedding_dimensions(model_choice: EmbeddingModel) -> int:
         return 1536
     elif model_choice == EmbeddingModel.OPENAI_LARGE_003:
         return 3072
+    elif model_choice == EmbeddingModel.JINA_V5_SMALL:
+        return 1024
+    elif model_choice == EmbeddingModel.JINA_V5_NANO:
+        return 768
     elif model_choice == EmbeddingModel.MOCK_MODEL:
         return 4  # A small, fixed dimension for testing
     else:
@@ -127,164 +139,268 @@ def get_onnx_cache_dir() -> Path:
 
 
 def get_local_embedding_model(model_choice: EmbeddingModel) -> dict:
-    """Get a cached ONNX embedding model instance."""
+    """Get a cached ONNX embedding model instance.
+
+    Automatically uses GPU if available and USE_GPU=True in settings.
+    Falls back to CPU-optimized quantized model otherwise.
+    """
     if model_choice not in _model_cache:
-        if (
-            model_choice == EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE
-            or model_choice == EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL
+        if model_choice not in (
+            EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE,
+            EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL,
+            EmbeddingModel.JINA_V5_NANO,
+            EmbeddingModel.JINA_V5_SMALL,
         ):
-            # Map LOCAL_E5_MULTILINGUAL to the LARGE variant for backward compatibility
-            model_name = model_choice.value
-
-            # Define cache directory for this specific model
-            cache_dir = get_onnx_cache_dir()
-            model_cache_path = cache_dir / model_name.replace("/", "_")
-            quantized_model_path = (
-                cache_dir / f"{model_name.replace('/', '_')}_quantized"
-            )
-
-            logger.info(f"Loading ONNX model: {model_name}")
-
-            sess_options = ort.SessionOptions()
-            sess_options.graph_optimization_level = (
-                ort.GraphOptimizationLevel.ORT_ENABLE_ALL
-            )
-            # Optimize for 4-core CPU
-            sess_options.intra_op_num_threads = 4  # Use all cores for operations
-            sess_options.inter_op_num_threads = 4  # Parallel execution across ops
-            sess_options.execution_mode = (
-                ort.ExecutionMode.ORT_PARALLEL
-            )  # Enable parallel execution
-
-            # Enable additional optimizations
-            sess_options.enable_cpu_mem_arena = True
-            sess_options.enable_mem_pattern = True
-            sess_options.enable_mem_reuse = True
-
-            # Check if quantized model exists
-            if (
-                quantized_model_path.exists()
-                and (quantized_model_path / "model_quantized.onnx").exists()
-            ):
-                logger.info(
-                    f"Loading quantized ONNX model from cache: {quantized_model_path}"
-                )
-                model = ORTModelForFeatureExtraction.from_pretrained(
-                    quantized_model_path,
-                    file_name="model_quantized.onnx",
-                    provider="CPUExecutionProvider",
-                    session_options=sess_options,
-                    provider_options={
-                        "CPUExecutionProvider": {
-                            "arena_extend_strategy": "kSameAsRequested",
-                        }
-                    },
-                )
-                tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
-            # Check if regular ONNX model exists
-            elif (
-                model_cache_path.exists() and (model_cache_path / "model.onnx").exists()
-            ):
-                logger.info(f"Loading ONNX model from cache: {model_cache_path}")
-                logger.info("Quantizing model to INT8 for faster inference...")
-
-                # Load the model first
-                model = ORTModelForFeatureExtraction.from_pretrained(
-                    model_cache_path,
-                    provider="CPUExecutionProvider",
-                    session_options=sess_options,
-                    provider_options={
-                        "CPUExecutionProvider": {
-                            "arena_extend_strategy": "kSameAsRequested",
-                        }
-                    },
-                )
-                tokenizer = AutoTokenizer.from_pretrained(model_cache_path)
-
-                # Quantize the model
-                quantizer = ORTQuantizer.from_pretrained(model)
-                qconfig = AutoQuantizationConfig.avx512_vnni(
-                    is_static=False, per_channel=False
-                )
-
-                # Save quantized model
-                quantized_model_path.mkdir(parents=True, exist_ok=True)
-                quantizer.quantize(
-                    save_dir=quantized_model_path,
-                    quantization_config=qconfig,
-                    file_suffix="quantized",
-                )
-                tokenizer.save_pretrained(quantized_model_path)
-
-                # Reload the quantized model
-                model = ORTModelForFeatureExtraction.from_pretrained(
-                    quantized_model_path,
-                    file_name="model_quantized.onnx",
-                    provider="CPUExecutionProvider",
-                    session_options=sess_options,
-                    provider_options={
-                        "CPUExecutionProvider": {
-                            "arena_extend_strategy": "kSameAsRequested",
-                        }
-                    },
-                )
-                logger.info(f"Quantized model saved to: {quantized_model_path}")
-            else:
-                logger.info(f"Exporting and saving ONNX model to: {model_cache_path}")
-                model = ORTModelForFeatureExtraction.from_pretrained(
-                    model_name,
-                    export=True,
-                    provider="CPUExecutionProvider",
-                    session_options=sess_options,
-                    provider_options={
-                        "CPUExecutionProvider": {
-                            "arena_extend_strategy": "kSameAsRequested",
-                        }
-                    },
-                )
-                tokenizer = AutoTokenizer.from_pretrained(model_name)
-
-                # Save the model and tokenizer to disk
-                model.save_pretrained(model_cache_path)
-                tokenizer.save_pretrained(model_cache_path)
-                logger.info(f"ONNX model saved to cache: {model_cache_path}")
-
-                # Quantize the newly exported model
-                logger.info("Quantizing model to INT8 for faster inference...")
-                quantizer = ORTQuantizer.from_pretrained(model)
-                qconfig = AutoQuantizationConfig.avx512_vnni(
-                    is_static=False, per_channel=False
-                )
-
-                quantized_model_path.mkdir(parents=True, exist_ok=True)
-                quantizer.quantize(
-                    save_dir=quantized_model_path,
-                    quantization_config=qconfig,
-                    file_suffix="quantized",
-                )
-                tokenizer.save_pretrained(quantized_model_path)
-
-                # Reload the quantized model
-                model = ORTModelForFeatureExtraction.from_pretrained(
-                    quantized_model_path,
-                    file_name="model_quantized.onnx",
-                    provider="CPUExecutionProvider",
-                    session_options=sess_options,
-                    provider_options={
-                        "CPUExecutionProvider": {
-                            "arena_extend_strategy": "kSameAsRequested",
-                        }
-                    },
-                )
-                logger.info(f"Quantized model saved to: {quantized_model_path}")
-
-            _model_cache[model_choice] = {"model": model, "tokenizer": tokenizer}
-
-            logger.info("ONNX model loaded successfully")
-        else:
             raise ValueError(f"Local model not supported: {model_choice}")
 
+        model_name = model_choice.value
+        settings = get_settings()
+        use_gpu = settings.USE_GPU
+
+        # Define cache directory for this specific model
+        # Use separate cache paths for GPU vs CPU to avoid loading wrong model variant
+        cache_dir = get_onnx_cache_dir()
+        model_cache_path = (
+            cache_dir / f"{model_name.replace('/', '_')}{'_gpu' if use_gpu else ''}"
+        )
+        quantized_model_path = cache_dir / f"{model_name.replace('/', '_')}_quantized"
+
+        # Check GPU availability
+        if use_gpu:
+            if torch.cuda.is_available():
+                gpu_count = torch.cuda.device_count()
+                gpu_name = torch.cuda.get_device_name(0) if gpu_count > 0 else "Unknown"
+                logger.info(
+                    f"GPU acceleration enabled. Found {gpu_count} GPU(s): {gpu_name}"
+                )
+            else:
+                logger.warning(
+                    "USE_GPU=True but CUDA is not available. Falling back to CPU."
+                )
+                use_gpu = False
+                # Update cache path for CPU fallback
+                model_cache_path = cache_dir / model_name.replace("/", "_")
+
+        logger.info(f"Loading ONNX model: {model_name} (GPU: {use_gpu})")
+
+        if use_gpu:
+            # GPU path: Load model without quantization for better GPU performance
+            device_ids = [int(d.strip()) for d in settings.GPU_DEVICE_IDS.split(",")]
+            logger.info(f"Using GPU devices: {device_ids}")
+
+            # Load one model instance per GPU for parallel processing
+            models_per_gpu = []
+            for device_id in device_ids:
+                model, tokenizer = _load_model_for_gpu(
+                    model_name, model_cache_path, device_id
+                )
+                models_per_gpu.append((model, tokenizer, device_id))
+
+            # Use first model/tokenizer as primary (for single-GPU fallback)
+            model, tokenizer, _ = models_per_gpu[0]
+        else:
+            # CPU path: Use quantized model for faster CPU inference
+            model, tokenizer = _load_model_for_cpu(
+                model_name, model_cache_path, quantized_model_path
+            )
+            models_per_gpu = None
+
+        _model_cache[model_choice] = {
+            "model": model,
+            "tokenizer": tokenizer,
+            "use_gpu": use_gpu,
+            "models_per_gpu": models_per_gpu,
+        }
+
+        logger.info(f"ONNX model loaded successfully (GPU: {use_gpu})")
+
     return _model_cache[model_choice]
+
+
+def _load_model_for_gpu(
+    model_name: str, model_cache_path: Path, device_id: int = 0
+) -> tuple:
+    """Load ONNX model optimized for GPU inference.
+
+    GPU inference works best with non-quantized FP32 models.
+
+    Args:
+        model_name: HuggingFace model name
+        model_cache_path: Path to cache directory
+        device_id: GPU device ID to use (default: 0)
+    """
+    settings = get_settings()
+    gpu_mem_limit = (
+        settings.GPU_MEMORY_LIMIT_GB * 1024 * 1024 * 1024
+    )  # Convert GB to bytes
+
+    provider_options = {
+        "device_id": device_id,
+        "arena_extend_strategy": "kNextPowerOfTwo",
+        "gpu_mem_limit": gpu_mem_limit,
+        "cudnn_conv_algo_search": "EXHAUSTIVE",
+    }
+
+    # Check if model exists in cache
+    if model_cache_path.exists() and (model_cache_path / "model.onnx").exists():
+        logger.info(
+            f"Loading ONNX model from cache: {model_cache_path} (GPU {device_id})"
+        )
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            model_cache_path,
+            provider="CUDAExecutionProvider",
+            provider_options=provider_options,
+        )
+        tokenizer = AutoTokenizer.from_pretrained(model_cache_path)
+    else:
+        logger.info(
+            f"Exporting and saving ONNX model to: {model_cache_path} (GPU {device_id})"
+        )
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            model_name,
+            export=True,
+            provider="CUDAExecutionProvider",
+            provider_options=provider_options,
+        )
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+        # Save the model and tokenizer to disk
+        model_cache_path.mkdir(parents=True, exist_ok=True)
+        model.save_pretrained(model_cache_path)
+        tokenizer.save_pretrained(model_cache_path)
+        logger.info(f"ONNX model saved to cache: {model_cache_path}")
+
+    return model, tokenizer
+
+
+def _load_model_for_cpu(
+    model_name: str, model_cache_path: Path, quantized_model_path: Path
+) -> tuple:
+    """Load ONNX model optimized for CPU inference with INT8 quantization."""
+    settings = get_settings()
+    num_threads = settings.CPU_NUM_THREADS
+
+    sess_options = ort.SessionOptions()
+    sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+    sess_options.intra_op_num_threads = num_threads
+    sess_options.inter_op_num_threads = num_threads
+    sess_options.execution_mode = ort.ExecutionMode.ORT_PARALLEL
+
+    # Enable additional optimizations
+    sess_options.enable_cpu_mem_arena = True
+    sess_options.enable_mem_pattern = True
+    sess_options.enable_mem_reuse = True
+
+    # Check if quantized model exists
+    if (
+        quantized_model_path.exists()
+        and (quantized_model_path / "model_quantized.onnx").exists()
+    ):
+        logger.info(f"Loading quantized ONNX model from cache: {quantized_model_path}")
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            quantized_model_path,
+            file_name="model_quantized.onnx",
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {
+                    "arena_extend_strategy": "kSameAsRequested",
+                }
+            },
+        )
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+    # Check if regular ONNX model exists
+    elif model_cache_path.exists() and (model_cache_path / "model.onnx").exists():
+        logger.info(f"Loading ONNX model from cache: {model_cache_path}")
+        logger.info("Quantizing model to INT8 for faster inference...")
+
+        # Load the model first
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            model_cache_path,
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {
+                    "arena_extend_strategy": "kSameAsRequested",
+                }
+            },
+        )
+        tokenizer = AutoTokenizer.from_pretrained(model_cache_path)
+
+        # Quantize the model
+        quantizer = ORTQuantizer.from_pretrained(model)
+        qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=False)
+
+        # Save quantized model
+        quantized_model_path.mkdir(parents=True, exist_ok=True)
+        quantizer.quantize(
+            save_dir=quantized_model_path,
+            quantization_config=qconfig,
+            file_suffix="quantized",
+        )
+        tokenizer.save_pretrained(quantized_model_path)
+
+        # Reload the quantized model
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            quantized_model_path,
+            file_name="model_quantized.onnx",
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {
+                    "arena_extend_strategy": "kSameAsRequested",
+                }
+            },
+        )
+        logger.info(f"Quantized model saved to: {quantized_model_path}")
+    else:
+        logger.info(f"Exporting and saving ONNX model to: {model_cache_path}")
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            model_name,
+            export=True,
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {
+                    "arena_extend_strategy": "kSameAsRequested",
+                }
+            },
+        )
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+        # Save the model and tokenizer to disk
+        model.save_pretrained(model_cache_path)
+        tokenizer.save_pretrained(model_cache_path)
+        logger.info(f"ONNX model saved to cache: {model_cache_path}")
+
+        # Quantize the newly exported model
+        logger.info("Quantizing model to INT8 for faster inference...")
+        quantizer = ORTQuantizer.from_pretrained(model)
+        qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=False)
+
+        quantized_model_path.mkdir(parents=True, exist_ok=True)
+        quantizer.quantize(
+            save_dir=quantized_model_path,
+            quantization_config=qconfig,
+            file_suffix="quantized",
+        )
+        tokenizer.save_pretrained(quantized_model_path)
+
+        # Reload the quantized model
+        model = ORTModelForFeatureExtraction.from_pretrained(
+            quantized_model_path,
+            file_name="model_quantized.onnx",
+            provider="CPUExecutionProvider",
+            session_options=sess_options,
+            provider_options={
+                "CPUExecutionProvider": {
+                    "arena_extend_strategy": "kSameAsRequested",
+                }
+            },
+        )
+        logger.info(f"Quantized model saved to: {quantized_model_path}")
+
+    return model, tokenizer
 
 
 def create_optimal_request_batches(
@@ -324,35 +440,147 @@ def create_optimal_request_batches(
     return batches
 
 
-def create_text_batches(texts: List[str], batch_size: int = 32) -> List[List[str]]:
+def create_text_batches(texts: list[str], batch_size: int = 32) -> list[list[str]]:
     """Create batches of texts for parallel processing."""
-    batches = []
+    return [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
+
+
+def _compute_embeddings(
+    model: ORTModelForFeatureExtraction,
+    tokenizer: PreTrainedTokenizerBase,
+    texts: list[str],
+    device_id: int | None = None,
+) -> list[list[float]]:
+    """Compute mean-pooled normalized embeddings for a batch of texts."""
+
+    encoded = tokenizer(
+        texts,
+        padding=True,
+        truncation=True,
+        return_tensors="pt",
+        return_token_type_ids=False,
+        return_attention_mask=True,
+    )
+
+    # Move tensors to GPU if specified
+    if device_id is not None:
+        encoded = {k: v.cuda(device_id) for k, v in encoded.items()}
+
+    with torch.no_grad():
+        outputs = model(**encoded)
+        token_embeddings = outputs.last_hidden_state
+        attention_mask = encoded["attention_mask"]
+
+        # Mean pooling with attention mask
+        input_mask_expanded = (
+            attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        )
+        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+        embeddings = sum_embeddings / sum_mask
+
+        # L2 normalize
+        embeddings = normalize(embeddings, p=2, dim=1)
+
+    return list(embeddings.cpu().numpy().tolist())
+
+
+def _generate_embeddings_single_device(
+    texts: list[tuple[str, TextType]],
+    model: ORTModelForFeatureExtraction,
+    tokenizer: PreTrainedTokenizerBase,
+    use_gpu: bool,
+    batch_size: int,
+) -> list[list[float]]:
+    """Generate embeddings using a single device (CPU or single GPU)."""
+    all_embeddings = []
+    device_id = 0 if use_gpu else None
+    total_batches = (len(texts) + batch_size - 1) // batch_size
+
     for i in range(0, len(texts), batch_size):
-        batches.append(texts[i : i + batch_size])
-    return batches
+        batch_texts = texts[i : i + batch_size]
+        formatted_texts = [f"{text[1].value}: {text[0]}" for text in batch_texts]
+
+        embeddings = _compute_embeddings(model, tokenizer, formatted_texts, device_id)
+        all_embeddings.extend(embeddings)
+
+        if total_batches > 1:
+            logger.debug(f"Processed batch {i // batch_size + 1}/{total_batches}")
+
+    return all_embeddings
 
 
-class TextType(str, Enum):
-    QUERY = "query"
-    PASSAGE = "passage"
+def _generate_embeddings_multi_gpu(
+    texts: list[tuple[str, TextType]],
+    models_per_gpu: list[
+        tuple[ORTModelForFeatureExtraction, PreTrainedTokenizerBase, int]
+    ],
+    tokenizer: PreTrainedTokenizerBase,
+    batch_size: int,
+) -> list[list[float]]:
+    """Generate embeddings using multiple GPUs in parallel."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    num_gpus = len(models_per_gpu)
+    logger.info(f"Processing {len(texts)} texts across {num_gpus} GPUs")
+
+    # Split texts into chunks for each GPU
+    chunk_size = (len(texts) + num_gpus - 1) // num_gpus
+    chunks = [texts[i : i + chunk_size] for i in range(0, len(texts), chunk_size)]
+
+    # Pad with empty lists to match GPU count
+    chunks.extend([[] for _ in range(num_gpus - len(chunks))])
+
+    all_embeddings: list[list[list[float]]] = [[] for _ in range(len(chunks))]
+
+    def process_chunk(
+        chunk_idx: int, chunk: list, model_tokenizer_device: tuple
+    ) -> tuple[int, list[list[float]]]:
+        """Process a chunk of texts on a specific GPU."""
+        model, _, device_id = model_tokenizer_device
+
+        if not chunk:
+            return chunk_idx, []
+
+        chunk_embeddings = []
+        total_batches = (len(chunk) + batch_size - 1) // batch_size
+
+        for i in range(0, len(chunk), batch_size):
+            batch_texts = chunk[i : i + batch_size]
+            formatted_texts = [f"{text[1].value}: {text[0]}" for text in batch_texts]
+
+            embeddings = _compute_embeddings(
+                model, tokenizer, formatted_texts, device_id
+            )
+            chunk_embeddings.extend(embeddings)
+
+            if total_batches > 1:
+                logger.debug(
+                    f"GPU {device_id}: Processed batch {i // batch_size + 1}/{total_batches}"
+                )
+
+        return chunk_idx, chunk_embeddings
+
+    # Process chunks in parallel across GPUs
+    with ThreadPoolExecutor(max_workers=num_gpus) as executor:
+        futures = [
+            executor.submit(process_chunk, idx, chunk, mtd)
+            for idx, (chunk, mtd) in enumerate(zip(chunks, models_per_gpu))
+        ]
+        for future in as_completed(futures):
+            chunk_idx, chunk_embeddings = future.result()
+            all_embeddings[chunk_idx] = chunk_embeddings
+
+    # Flatten results in order
+    result = [emb for chunk_embs in all_embeddings for emb in chunk_embs]
+    logger.info(f"Multi-GPU processing complete: {len(result)} embeddings generated")
+    return result
 
 
 def generate_embeddings(
     texts: list[tuple[str, TextType]], model_choice: EmbeddingModel
 ) -> list[list[float]]:
-    """Generate embeddings for a list of texts using the specified model.
-
-    Args:
-        texts: List of text strings to embed. Must not contain empty strings.
-        model_choice: The embedding model to use.
-        query: Whether to use query prefix (for E5 models).
-
-    Returns:
-        List of embeddings, one per input text.
-
-    Raises:
-        ValueError: If any text in the list is empty or whitespace-only.
-    """
+    """Generate embeddings for a list of texts using the specified model."""
     # Handle empty input early
     if not texts:
         return []
@@ -375,56 +603,33 @@ def generate_embeddings(
             for t in texts
         ]
 
-    elif (
-        model_choice == EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE
-        or model_choice == EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL
+    elif model_choice in (
+        EmbeddingModel.LOCAL_MULTILINGUAL_E5_LARGE,
+        EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL,
+        EmbeddingModel.JINA_V5_SMALL,
+        EmbeddingModel.JINA_V5_NANO,
     ):
         model_data = get_local_embedding_model(model_choice)
         model = model_data["model"]
         tokenizer = model_data["tokenizer"]
+        use_gpu = model_data.get("use_gpu", False)
+        models_per_gpu = model_data.get("models_per_gpu")
 
-        # Process in batches for better performance
-        batch_size = 16  # Adjust based on memory constraints
-        all_embeddings = []
+        # Use larger batch size for GPU, smaller for CPU
+        settings = get_settings()
+        batch_size = settings.GPU_BATCH_SIZE if use_gpu else settings.CPU_BATCH_SIZE
 
-        for i in range(0, len(texts), batch_size):
-            batch_texts = texts[i : i + batch_size]
-
-            formatted_texts = [f"{text[1].value}: {text[0]}" for text in batch_texts]
-
-            encoded = tokenizer(
-                formatted_texts,
-                padding=True,
-                truncation=True,
-                max_length=512,
-                return_tensors="pt",
-                return_token_type_ids=False,  # Disable if not needed
-                return_attention_mask=True,
+        # Check if we have multiple GPUs for parallel processing
+        if use_gpu and models_per_gpu and len(models_per_gpu) > 1:
+            # Multi-GPU parallel processing
+            all_embeddings = _generate_embeddings_multi_gpu(
+                texts, models_per_gpu, tokenizer, batch_size
             )
-
-            with torch.no_grad():
-                outputs = model(**encoded)
-
-                token_embeddings = outputs.last_hidden_state
-                attention_mask = encoded["attention_mask"]
-
-                input_mask_expanded = (
-                    attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-                )
-
-                sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
-                sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
-                embeddings = sum_embeddings / sum_mask
-
-                embeddings = normalize(embeddings, p=2, dim=1)
-
-            batch_result: list[list[float]] = embeddings.cpu().numpy().tolist()
-            all_embeddings.extend(batch_result)
-
-            if len(texts) > batch_size:
-                logger.debug(
-                    f"Processed batch {i // batch_size + 1}/{(len(texts) - 1) // batch_size + 1}"
-                )
+        else:
+            # Single GPU or CPU processing
+            all_embeddings = _generate_embeddings_single_device(
+                texts, model, tokenizer, use_gpu, batch_size
+            )
 
         return all_embeddings
 
@@ -449,11 +654,11 @@ def generate_embeddings(
             )
             logger.info(f"Split into {len(batches)} batches for parallel processing.")
 
-            all_results: List[Optional[List[List[float]]]] = [None] * len(batches)
+            all_results: list[list[list[float]] | None] = [None] * len(batches)
 
             def process_batch(
-                batch_idx_batch: Tuple[int, List[str]],
-            ) -> Tuple[int, Optional[List[List[float]]]]:
+                batch_idx_batch: tuple[int, list[str]],
+            ) -> tuple[int, list[list[float]] | None]:
                 batch_idx, batch = batch_idx_batch
                 try:
                     _openai_rate_limiter.wait_if_needed(batch)

--- a/src/lex_db/embeddings.py
+++ b/src/lex_db/embeddings.py
@@ -448,7 +448,7 @@ class JinaV5ModelHandler:
     def _load_for_gpu(self) -> tuple:
         """Load SentenceTransformer model for GPU inference."""
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        logger.info(f"Loading Jina v5 model for GPU: {self.model_name}")
+        logger.info(f"Loading Jina v5 model: {self.model_name}, on {device}")
 
         model_kwargs: dict = {"trust_remote_code": True}
 
@@ -645,19 +645,13 @@ def get_local_embedding_model(model_choice: EmbeddingModel) -> dict:
     if model_choice not in _model_cache:
         handler = get_handler(model_choice)
 
-        settings = get_settings()
-        use_gpu = settings.USE_GPU
-
-        # Check GPU availability
+        # Automatically detect GPU availability
+        use_gpu = torch.cuda.is_available()
         if use_gpu:
-            if torch.cuda.is_available():
-                gpu_name = torch.cuda.get_device_name(0)
-                logger.info(f"GPU acceleration enabled. Using: {gpu_name}")
-            else:
-                logger.warning(
-                    "USE_GPU=True but CUDA is not available. Falling back to CPU."
-                )
-                use_gpu = False
+            gpu_name = torch.cuda.get_device_name(0)
+            logger.info(f"GPU acceleration enabled. Using: {gpu_name}")
+        else:
+            logger.info("CUDA not available, using CPU for inference")
 
         model, tokenizer, actual_use_gpu = handler.load_model(use_gpu)
 

--- a/src/scripts/dump_articles.py
+++ b/src/scripts/dump_articles.py
@@ -1,0 +1,173 @@
+"""CLI tool to dump articles from the database to JSONL format.
+
+This script exports articles from the PostgreSQL database to a JSONL file
+that can be processed on a remote server for embedding generation.
+
+Two modes are supported:
+- full: Dump all articles (default)
+- incremental: Only dump articles that have changed since last vector index update
+"""
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+from lex_db.database import get_db_connection
+from lex_db.config import get_settings
+from lex_db.utils import get_logger, configure_logging
+from lex_db.vector_store import get_vector_index_metadata
+
+logger = get_logger()
+
+
+def dump_articles(
+    output_file: str,
+    mode: str = "full",
+    index_name: str | None = None,
+) -> dict[str, int]:
+    """
+    Dump articles from the database to a JSONL file.
+
+    Args:
+        output_file: Path to the output JSONL file
+        mode: "full" to dump all articles, "incremental" to dump only changed articles
+        index_name: Name of the vector index (required for incremental mode)
+
+    Returns:
+        Dictionary with stats: {"total_articles": N, "dumped_articles": M}
+    """
+    stats = {"total_articles": 0, "dumped_articles": 0}
+
+    with get_db_connection() as db_conn:
+        # Get total article count
+        result = db_conn.execute("SELECT COUNT(*) as count FROM articles").fetchone()
+        stats["total_articles"] = result["count"] if result else 1  # type: ignore
+        logger.info(f"Total articles in database: {stats['total_articles']}")
+
+        # Build query based on mode
+        if mode == "incremental":
+            if not index_name:
+                raise ValueError("index_name is required for incremental mode")
+
+            # Get metadata for the vector index
+            metadata = get_vector_index_metadata(db_conn, index_name)
+            if not metadata:
+                raise ValueError(f"No metadata found for vector index '{index_name}'")
+
+            updated_at_column = metadata.get("updated_at_column", "changed_at")
+            logger.info(f"Using incremental mode with column: {updated_at_column}")
+
+            # Find articles that have changed since the vector index was last updated
+            # or articles that don't exist in the vector index at all
+            query = f"""
+                SELECT DISTINCT a.id, a.headword, a.xhtml_md, a.permalink, 
+                       a.encyclopedia_id, a.changed_at, a.created_at
+                FROM articles a
+                LEFT JOIN {index_name} vi ON a.id = vi.source_article_id
+                WHERE vi.source_article_id IS NULL
+                   OR a.{updated_at_column} > vi.last_updated
+                ORDER BY a.id
+            """
+        else:
+            # Full dump - get all articles
+            query = """
+                SELECT id, headword, xhtml_md, permalink, 
+                       encyclopedia_id, changed_at, created_at
+                FROM articles
+                ORDER BY id
+            """
+
+        # Open output file and write metadata header
+        with open(output_file, "w", encoding="utf-8") as f:
+            # Write metadata header
+            metadata_header = {
+                "_metadata": {
+                    "dump_date": datetime.now(timezone.utc).isoformat(),
+                    "mode": mode,
+                    "index_name": index_name,
+                    "total_articles_in_db": stats["total_articles"],
+                }
+            }
+            f.write(json.dumps(metadata_header, ensure_ascii=False) + "\n")
+
+            # Stream articles to file
+            logger.info(f"Starting {mode} dump to {output_file}...")
+            cursor = db_conn.execute(query)  # type: ignore
+
+            for row in cursor:
+                # Handle datetime fields - they may be datetime objects or strings
+                changed_at = row["changed_at"]  # type: ignore[call-overload]
+                if changed_at and hasattr(changed_at, "isoformat"):
+                    changed_at = changed_at.isoformat()
+                created_at = row["created_at"]  # type: ignore[call-overload]
+                if created_at and hasattr(created_at, "isoformat"):
+                    created_at = created_at.isoformat()
+
+                article = {
+                    "id": row["id"],  # type: ignore[call-overload]
+                    "headword": row["headword"],  # type: ignore[call-overload]
+                    "xhtml_md": row["xhtml_md"],  # type: ignore[call-overload]
+                    "permalink": row["permalink"],  # type: ignore[call-overload]
+                    "encyclopedia_id": row["encyclopedia_id"],  # type: ignore[call-overload]
+                    "changed_at": changed_at,
+                    "created_at": created_at,
+                }
+                f.write(json.dumps(article, ensure_ascii=False) + "\n")
+                stats["dumped_articles"] += 1
+
+                # Log progress every 10000 articles
+                if stats["dumped_articles"] % 10000 == 0:
+                    logger.info(f"Dumped {stats['dumped_articles']} articles...")
+
+    logger.info(
+        f"Dump complete: {stats['dumped_articles']} articles written to {output_file}"
+    )
+    return stats
+
+
+def main() -> None:
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description="Dump articles from database to JSONL format for remote processing"
+    )
+    parser.add_argument("--output", "-o", required=True, help="Output JSONL file path")
+    parser.add_argument(
+        "--mode",
+        choices=["full", "incremental"],
+        default="full",
+        help="Dump mode: 'full' for all articles, 'incremental' for changed articles only (default: full)",
+    )
+    parser.add_argument(
+        "--index-name",
+        "-i",
+        help="Name of the vector index (required for incremental mode)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
+    args = parser.parse_args()
+    configure_logging(args.debug)
+
+    # Validate arguments
+    if args.mode == "incremental" and not args.index_name:
+        parser.error("--index-name is required when using incremental mode")
+
+    settings = get_settings()
+    try:
+        logger.info(f"Connecting to database at {settings.DATABASE_URL}")
+        stats = dump_articles(
+            output_file=args.output,
+            mode=args.mode,
+            index_name=args.index_name,
+        )
+
+        logger.info(f"Successfully dumped {stats['dumped_articles']} articles")
+        if stats["dumped_articles"] == 0:
+            logger.warning("No articles were dumped. Check your filters.")
+
+    except Exception as e:
+        logger.error(f"Error dumping articles: {str(e)}", exc_info=True)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/generate_embeddings.py
+++ b/src/scripts/generate_embeddings.py
@@ -1,0 +1,270 @@
+"""CLI tool to generate embeddings from a JSONL articles dump.
+
+This script reads articles from a JSONL file (produced by dump_articles.py),
+chunks the text, generates embeddings, and outputs a JSONL file that can be
+imported using import_vector_embeddings.py.
+
+This script is designed to run on a remote server without database access.
+"""
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+from lex_db.utils import (
+    get_logger,
+    configure_logging,
+    ChunkingStrategy,
+    split_document_into_chunks,
+)
+from lex_db.embeddings import (
+    EmbeddingModel,
+    TextType,
+    generate_embeddings,
+    get_embedding_dimensions,
+)
+
+logger = get_logger()
+
+
+def generate_embeddings_from_jsonl(
+    input_file: str,
+    output_file: str,
+    embedding_model_choice: EmbeddingModel,
+    chunk_size: int = 512,
+    chunk_overlap: int = 50,
+    chunking_strategy: ChunkingStrategy = ChunkingStrategy.SECTIONS,
+    batch_size: int = 2048,
+) -> dict[str, int]:
+    """
+    Generate embeddings from a JSONL articles dump.
+
+    Args:
+        input_file: Path to input JSONL file with articles
+        output_file: Path to output JSONL file with embeddings
+        embedding_model_choice: Model to use for generating embeddings
+        chunk_size: Size of text chunks for embedding
+        chunk_overlap: Overlap between consecutive chunks
+        chunking_strategy: Strategy for splitting text into chunks
+        batch_size: Number of chunks to process per batch
+
+    Returns:
+        Dictionary with stats: {"articles_processed": N, "chunks_created": M, "errors": K}
+    """
+    stats = {"articles_processed": 0, "chunks_created": 0, "errors": 0}
+
+    # Read metadata and articles from input file
+    logger.info(f"Reading articles from {input_file}")
+    articles = []
+    metadata = None
+
+    with open(input_file, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            try:
+                data = json.loads(line)
+
+                # First line should be metadata
+                if line_num == 1 and "_metadata" in data:
+                    metadata = data["_metadata"]
+                    logger.info(f"Input metadata: {metadata}")
+                    continue
+
+                # Regular article line
+                articles.append(data)
+
+                # Log progress every 10000 articles
+                if len(articles) % 10000 == 0:
+                    logger.info(f"Loaded {len(articles)} articles...")
+
+            except json.JSONDecodeError as e:
+                logger.error(f"Error parsing line {line_num}: {e}")
+                stats["errors"] += 1
+
+    logger.info(f"Loaded {len(articles)} articles from {input_file}")
+
+    # Prepare chunks for all articles
+    logger.info("Chunking articles...")
+    all_chunks = []  # List of (article_id, chunk_idx, chunk_text)
+
+    for article in articles:
+        try:
+            article_id = article["id"]
+            headword = article.get("headword", "")
+            text = article.get("xhtml_md", "")
+
+            if not text:
+                logger.warning(f"Article {article_id} has no text content, skipping")
+                stats["errors"] += 1
+                continue
+
+            # Prepend headword as title (same as update_vector_index does)
+            article_text = f"# {headword}\n{text}"
+
+            # Split into chunks
+            chunks = split_document_into_chunks(
+                article_text,
+                chunk_size=chunk_size,
+                overlap=chunk_overlap,
+                chunking_strategy=chunking_strategy,
+            )
+
+            for chunk_idx, chunk_text in enumerate(chunks):
+                all_chunks.append((article_id, chunk_idx, chunk_text))
+
+            stats["articles_processed"] += 1
+
+            # Log progress every 1000 articles
+            if stats["articles_processed"] % 1000 == 0:
+                logger.info(
+                    f"Chunked {stats['articles_processed']} articles, "
+                    f"{len(all_chunks)} total chunks"
+                )
+
+        except Exception as e:
+            logger.error(f"Error chunking article {article.get('id', 'unknown')}: {e}")
+            stats["errors"] += 1
+
+    logger.info(
+        f"Chunking complete: {len(all_chunks)} chunks from "
+        f"{stats['articles_processed']} articles"
+    )
+
+    # Generate embeddings in batches and write to output
+    logger.info(f"Generating embeddings using {embedding_model_choice.value}...")
+    embedding_dim = get_embedding_dimensions(embedding_model_choice)
+    logger.info(f"Embedding dimension: {embedding_dim}")
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        # Write metadata header
+        output_metadata = {
+            "_metadata": {
+                "index_name": None,  # Will be set during import
+                "total_chunks": len(all_chunks),
+                "export_date": datetime.now(timezone.utc).isoformat(),
+                "embedding_model": embedding_model_choice.value,
+                "embedding_dimensions": embedding_dim,
+                "chunk_size": chunk_size,
+                "chunk_overlap": chunk_overlap,
+                "chunking_strategy": chunking_strategy.value,
+                "source_dump": metadata,
+            }
+        }
+        f.write(json.dumps(output_metadata, ensure_ascii=False) + "\n")
+
+        # Process chunks in batches
+        total_batches = (len(all_chunks) + batch_size - 1) // batch_size
+
+        for batch_idx in range(0, len(all_chunks), batch_size):
+            batch = all_chunks[batch_idx : batch_idx + batch_size]
+            batch_num = batch_idx // batch_size + 1
+
+            try:
+                # Generate embeddings for this batch
+                texts_to_embed = [
+                    (chunk_text, TextType.PASSAGE) for _, _, chunk_text in batch
+                ]
+                embeddings = generate_embeddings(texts_to_embed, embedding_model_choice)
+
+                # Write each chunk with its embedding
+                for (article_id, chunk_idx, chunk_text), embedding in zip(
+                    batch, embeddings
+                ):
+                    chunk_data = {
+                        "article_id": article_id,
+                        "chunk_idx": chunk_idx,
+                        "chunk_text": chunk_text,
+                        "embedding": embedding,
+                    }
+                    f.write(json.dumps(chunk_data, ensure_ascii=False) + "\n")
+                    stats["chunks_created"] += 1
+
+                # Log progress
+                if batch_num % 10 == 0 or batch_num == total_batches:
+                    logger.info(
+                        f"Processed batch {batch_num}/{total_batches}: "
+                        f"{stats['chunks_created']}/{len(all_chunks)} chunks"
+                    )
+
+            except Exception as e:
+                logger.error(f"Error processing batch {batch_num}: {e}")
+                stats["errors"] += len(batch)
+
+    logger.info(
+        f"Embedding generation complete: {stats['chunks_created']} chunks written to {output_file}"
+    )
+    return stats
+
+
+def main() -> None:
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description="Generate embeddings from JSONL articles dump for remote processing"
+    )
+    parser.add_argument(
+        "--input", "-i", required=True, help="Input JSONL file with articles"
+    )
+    parser.add_argument(
+        "--output", "-o", required=True, help="Output JSONL file for embeddings"
+    )
+    parser.add_argument(
+        "--embedding-model",
+        "-e",
+        choices=[m.value for m in EmbeddingModel],
+        default=EmbeddingModel.LOCAL_MULTILINGUAL_E5_SMALL.value,
+        help="Embedding model to use (default: intfloat/multilingual-e5-small)",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=512,
+        help="Size of text chunks for embedding (default: 512)",
+    )
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        default=50,
+        help="Overlap between consecutive chunks (default: 50)",
+    )
+    parser.add_argument(
+        "--chunking-strategy",
+        default=ChunkingStrategy.SECTIONS.value,
+        choices=[s.value for s in ChunkingStrategy],
+        help="Strategy for splitting text into chunks (default: sections)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=2048,
+        help="Number of chunks to process per batch (default: 2048)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
+    args = parser.parse_args()
+    configure_logging(args.debug)
+
+    try:
+        stats = generate_embeddings_from_jsonl(
+            input_file=args.input,
+            output_file=args.output,
+            embedding_model_choice=EmbeddingModel(args.embedding_model),
+            chunk_size=args.chunk_size,
+            chunk_overlap=args.chunk_overlap,
+            chunking_strategy=ChunkingStrategy(args.chunking_strategy),
+            batch_size=args.batch_size,
+        )
+
+        logger.info(
+            f"Successfully processed {stats['articles_processed']} articles, "
+            f"created {stats['chunks_created']} chunks"
+        )
+        if stats["errors"] > 0:
+            logger.warning(f"Encountered {stats['errors']} errors during processing")
+            exit(1)
+
+    except Exception as e:
+        logger.error(f"Error generating embeddings: {str(e)}", exc_info=True)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/sync_articles.py
+++ b/src/scripts/sync_articles.py
@@ -633,7 +633,7 @@ def main() -> None:
     parser.add_argument(
         "--skip-vector-update",
         action="store_true",
-        help="Skip updating vector indexes (useful for testing or if no indexes are configured)",
+        help="Skip updating vector indexes (useful for testing or for only updating the article content)",
     )
     parser.add_argument(
         "--skip-scraping",
@@ -657,6 +657,8 @@ def main() -> None:
                 dry_run=args.dry_run,
                 batch_size=args.batch_size,
                 encyclopedia_ids=encyclopedia_ids,
+                skip_scraping=args.skip_scraping,
+                skip_vector_update=args.skip_vector_update,
                 indexes_to_update={
                     name.strip() for name in args.vector_indexes.split(",")
                 },

--- a/src/scripts/sync_articles.py
+++ b/src/scripts/sync_articles.py
@@ -411,9 +411,10 @@ def delete_missing_articles_from_db(
     return deleted_count
 
 
-def update_all_vector_indexes(
+def update_vector_indexes(
     batch_size: int,
     dry_run: bool,
+    indexes_to_update: set[str] | None = None,
 ) -> dict[str, VectorIndexStats]:
     """
     Update all vector indexes.
@@ -439,6 +440,12 @@ def update_all_vector_indexes(
 
         for index_meta in all_indexes:
             index_name = index_meta["index_name"]
+            if indexes_to_update and index_name not in indexes_to_update:
+                logger.info(
+                    f"Skipping vector index '{index_name}' (not in specified list)"
+                )
+                continue
+
             logger.info(f"Updating vector index: {index_name}")
 
             try:
@@ -541,6 +548,7 @@ async def sync_articles_async(
     encyclopedia_ids: set[int] | None,
     skip_vector_update: bool = False,
     skip_scraping: bool = False,
+    indexes_to_update: set[str] | None = None,
 ) -> None:
     """
     Main async workflow for article synchronization.
@@ -588,7 +596,9 @@ async def sync_articles_async(
 
     # Step 6: Update vector indexes
     if not skip_vector_update:
-        stats.vector_stats = update_all_vector_indexes(batch_size, dry_run)
+        stats.vector_stats = update_vector_indexes(
+            batch_size, dry_run, indexes_to_update
+        )
 
     # Step 7: Log summary
     log_sync_summary(stats, dry_run, encyclopedia_ids, batch_size, skip_scraping)
@@ -630,6 +640,12 @@ def main() -> None:
         action="store_true",
         help="Skip fetching article JSON (useful for testing with existing database entries)",
     )
+    parser.add_argument(
+        "--vector-indexes",
+        type=str,
+        default="e5_small,article_embeddings_e5",
+        help="Comma-separated vector index names to update (e.g., 'index1,index2')",
+    )
 
     args = parser.parse_args()
     configure_logging(args.debug)
@@ -641,6 +657,9 @@ def main() -> None:
                 dry_run=args.dry_run,
                 batch_size=args.batch_size,
                 encyclopedia_ids=encyclopedia_ids,
+                indexes_to_update={
+                    name.strip() for name in args.vector_indexes.split(",")
+                },
             )
         )
     except ValueError as e:

--- a/src/scripts/update_vector_indexes.py
+++ b/src/scripts/update_vector_indexes.py
@@ -29,7 +29,9 @@ def main() -> None:
 
     settings = get_settings()
     try:
-        logger.info(f"Connecting to database at {settings.DATABASE_URL}")
+        logger.info(
+            f"Connecting to {settings.DB_NAME} at {settings.DB_HOST}:{settings.DB_PORT}"
+        )
         with get_db_connection() as db_conn:
             # Fetch metadata for the index
             metadata = get_vector_index_metadata(db_conn, args.index_name)

--- a/src/tests/test_embeddings.py
+++ b/src/tests/test_embeddings.py
@@ -6,7 +6,6 @@ from lex_db.embeddings import (
     TextType,
     get_embedding_dimensions,
     generate_embeddings,
-    create_text_batches,
 )
 
 
@@ -155,30 +154,3 @@ class TestGenerateQueryEmbedding:
         """Test empty query text raises error."""
         with pytest.raises(ValueError, match="empty/whitespace-only texts"):
             generate_embeddings([("", TextType.QUERY)], mock_embedding_model)
-
-
-class TestCreateTextBatches:
-    """Tests for create_text_batches function."""
-
-    def test_single_batch(self) -> None:
-        """Test texts fit in single batch."""
-        texts = ["text1", "text2", "text3"]
-        batches = create_text_batches(texts, batch_size=10)
-
-        assert len(batches) == 1
-        assert batches[0] == texts
-
-    def test_multiple_batches(self) -> None:
-        """Test texts split into multiple batches."""
-        texts = ["text1", "text2", "text3", "text4", "text5"]
-        batches = create_text_batches(texts, batch_size=2)
-
-        assert len(batches) == 3
-        assert batches[0] == ["text1", "text2"]
-        assert batches[1] == ["text3", "text4"]
-        assert batches[2] == ["text5"]
-
-    def test_empty_texts(self) -> None:
-        """Test empty texts list returns empty batches."""
-        batches = create_text_batches([], batch_size=10)
-        assert batches == []

--- a/src/tests/test_sync_articles.py
+++ b/src/tests/test_sync_articles.py
@@ -530,7 +530,7 @@ class TestSyncArticlesAsync:
             new_callable=AsyncMock,
         ) as mock_fetch:
             with patch(
-                "scripts.sync_articles.update_all_vector_indexes"
+                "scripts.sync_articles.update_vector_indexes"
             ) as mock_update_vectors:
                 mock_update_vectors.return_value = None
 
@@ -560,7 +560,7 @@ class TestSyncArticlesAsync:
                     "scripts.sync_articles.delete_missing_articles_from_db"
                 ) as mock_delete:
                     with patch(
-                        "scripts.sync_articles.update_all_vector_indexes"
+                        "scripts.sync_articles.update_vector_indexes"
                     ) as mock_update_vectors:
                         mock_update_vectors.return_value = None
 
@@ -626,7 +626,7 @@ class TestSyncArticlesAsync:
                         mock_delete.return_value = 0
 
                         with patch(
-                            "scripts.sync_articles.update_all_vector_indexes"
+                            "scripts.sync_articles.update_vector_indexes"
                         ) as mock_update_vectors:
                             from scripts.sync_articles import sync_articles_async
 
@@ -644,4 +644,3 @@ class TestSyncArticlesAsync:
                             mock_fetch_content.assert_called_once()  # Should still fetch article content
                             mock_upsert.assert_called_once()  # Should still upsert articles
                             mock_delete.assert_called_once()  # Should still delete missing articles
-

--- a/uv.lock
+++ b/uv.lock
@@ -461,6 +461,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+gpu = [
+    { name = "onnxruntime-gpu" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -475,6 +480,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "markdownify", specifier = ">=1.2.2" },
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "onnxruntime-gpu", marker = "extra == 'gpu'", specifier = ">=1.16.0" },
     { name = "openai", specifier = ">=1.79.0" },
     { name = "optimum", extras = ["onnxruntime"], specifier = ">=2.0.0" },
     { name = "pgvector", specifier = ">=0.4.2" },
@@ -498,6 +504,7 @@ requires-dist = [
     { name = "types-setuptools", specifier = ">=80.8.0.20250521" },
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
+provides-extras = ["gpu"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -884,6 +891,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
     { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
     { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
+]
+
+[[package]]
+name = "onnxruntime-gpu"
+version = "1.24.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/fa/58ceca812214c9c1a286407c376e42e0b7de3e2c6e14b61cdf3caf6d6d9c/onnxruntime_gpu-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:537bdd6d95006a9200ae81f2e73ba9e621e723fdf0deb5901e2e62fb2cccf876", size = 252756089, upload-time = "2026-03-05T16:35:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/2f36920b513bd8939e25591153e37d9cfda94115bd119f2874da0750fce2/onnxruntime_gpu-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:d72065b3ab5fdaef74d8b6b8f39b7ce20d89731610e3e63cb40e997d3dce177e", size = 207197001, upload-time = "2026-03-05T16:40:05.691Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/9e6206dac76e08f028d2ae95f2ab1b3a7c3317fb6c0374a530aad48dab5c/onnxruntime_gpu-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3242a70010934e5bb0aeaa9dde4c25c6c2da577b55c6308c0caa828ba3b7be23", size = 252753349, upload-time = "2026-03-05T16:35:58.09Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ae/f0be395602c13a3a8d22fa6632133550a64536c58bc3623abbba5d0a575e/onnxruntime_gpu-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:a423b164dbc26cb7f8736367b11698c2a7294748d3c144c39542ecac28d225c9", size = 207197331, upload-time = "2026-03-05T16:40:14.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/af/a64c9789769d8d7fabc6d35dcce2f2897b2d9e0fe113044efc2903f7cd07/onnxruntime_gpu-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9696d54974a1313ef0d87f4cbd04f9abfd13839194638d52bb5967a15615341d", size = 252762923, upload-time = "2026-03-05T16:36:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bb/1cf7dffac2fb01e8de9f0882438165f7543f0aab57f86d1f587e6faa8528/onnxruntime_gpu-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8ca744f40b33380bc9136988213e574c927d2b919ed42149977e006b138f74f", size = 252754914, upload-time = "2026-03-05T16:36:30.739Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/39/3949d56103bd9cd9381de59b060f9bce8dc2c7363f465bf207ebd0c7a5d0/onnxruntime_gpu-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:c60c44e2b388720e6670a948b52626f3d089e960ef7da66e4fa6b2b33a11116f", size = 209599131, upload-time = "2026-03-05T16:40:24.074Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/60/51bfbcf2d0540dbfa426a73a9b80046b71a63de7303d16c0f2682c8edfd2/onnxruntime_gpu-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29048407a2398361d93de5537c2d2079d79d720337a0743d4a2cc28db981e776", size = 252764115, upload-time = "2026-03-05T16:36:44.681Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,24 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accelerate"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl", hash = "sha256:cf1a3efb96c18f7b152eb0fa7490f3710b19c3f395699358f08decca2b8b62e0", size = 383744, upload-time = "2026-03-04T19:34:10.313Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.17.2"
 source = { registry = "https://pypi.org/simple" }
@@ -134,18 +152,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
-]
-
-[[package]]
 name = "coverage"
 version = "7.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -185,6 +191,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "12.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/de/8ca2b613042550dcf9ef50c596c8b1f602afda92cf9032ac28a73f6ee410/cuda_pathfinder-1.4.2-py3-none-any.whl", hash = "sha256:eb354abc20278f8609dc5b666a24648655bef5613c6dfe78a238a6fd95566754", size = 44779, upload-time = "2026-03-10T21:57:30.974Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -218,11 +247,10 @@ wheels = [
 
 [[package]]
 name = "flatbuffers"
-version = "25.9.23"
+version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/1f/3ee70b0a55137442038f2a33469cc5fddd7e0ad2abf83d7497c18a2b6923/flatbuffers-25.9.23.tar.gz", hash = "sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12", size = 22067, upload-time = "2025-09-24T05:25:30.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/1b/00a78aa2e8fbd63f9af08c9c19e6deb3d5d66b4dda677a0f61654680ee89/flatbuffers-25.9.23-py2.py3-none-any.whl", hash = "sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2", size = 30869, upload-time = "2025-09-24T05:25:28.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -283,6 +311,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357, upload-time = "2026-03-13T06:58:51.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/06/e8cf74c3c48e5485c7acc5a990d0d8516cdfb5fdf80f799174f1287cc1b5/hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4", size = 3796125, upload-time = "2026-03-13T06:58:33.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d4/b73ebab01cbf60777323b7de9ef05550790451eb5172a220d6b9845385ec/hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81", size = 3555985, upload-time = "2026-03-13T06:58:31.797Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e7/ded6d1bd041c3f2bca9e913a0091adfe32371988e047dd3a68a2463c15a2/hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6", size = 4212085, upload-time = "2026-03-13T06:58:24.323Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c1/a0a44d1f98934f7bdf17f7a915b934f9fca44bb826628c553589900f6df8/hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555", size = 3988266, upload-time = "2026-03-13T06:58:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/82/be713b439060e7d1f1d93543c8053d4ef2fe7e6922c5b31642eaa26f3c4b/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496", size = 4188513, upload-time = "2026-03-13T06:58:40.858Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/cbd4188b22abd80ebd0edbb2b3e87f2633e958983519980815fb8314eae5/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d", size = 4428287, upload-time = "2026-03-13T06:58:42.601Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4e/84e45b25e2e3e903ed3db68d7eafa96dae9a1d1f6d0e7fc85120347a852f/hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0", size = 3665574, upload-time = "2026-03-13T06:58:53.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/71/c5ac2b9a7ae39c14e91973035286e73911c31980fe44e7b1d03730c00adc/hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82", size = 3528760, upload-time = "2026-03-13T06:58:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0f/fcd2504015eab26358d8f0f232a1aed6b8d363a011adef83fe130bff88f7/hf_xet-1.4.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:949dcf88b484bb9d9276ca83f6599e4aa03d493c08fc168c124ad10b2e6f75d7", size = 3796493, upload-time = "2026-03-13T06:58:39.267Z" },
+    { url = "https://files.pythonhosted.org/packages/82/56/19c25105ff81731ca6d55a188b5de2aa99d7a2644c7aa9de1810d5d3b726/hf_xet-1.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:41659966020d59eb9559c57de2cde8128b706a26a64c60f0531fa2318f409418", size = 3555797, upload-time = "2026-03-13T06:58:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/8933c073186849b5e06762aa89847991d913d10a95d1603eb7f2c3834086/hf_xet-1.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c588e21d80010119458dd5d02a69093f0d115d84e3467efe71ffb2c67c19146", size = 4212127, upload-time = "2026-03-13T06:58:30.539Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/01/f89ebba4e369b4ed699dcb60d3152753870996f41c6d22d3d7cac01310e1/hf_xet-1.4.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a296744d771a8621ad1d50c098d7ab975d599800dae6d48528ba3944e5001ba0", size = 3987788, upload-time = "2026-03-13T06:58:29.139Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4d/8a53e5ffbc2cc33bbf755382ac1552c6d9af13f623ed125fe67cc3e6772f/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f563f7efe49588b7d0629d18d36f46d1658fe7e08dce3fa3d6526e1c98315e2d", size = 4188315, upload-time = "2026-03-13T06:58:48.017Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b8/b7a1c1b5592254bd67050632ebbc1b42cc48588bf4757cb03c2ef87e704a/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5b2e0132c56d7ee1bf55bdb638c4b62e7106f6ac74f0b786fed499d5548c5570", size = 4428306, upload-time = "2026-03-13T06:58:49.502Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/40779e45b20e11c7c5821a94135e0207080d6b3d76e7b78ccb413c6f839b/hf_xet-1.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2f45c712c2fa1215713db10df6ac84b49d0e1c393465440e9cb1de73ecf7bbf6", size = 3665826, upload-time = "2026-03-13T06:58:59.88Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4c/e2688c8ad1760d7c30f7c429c79f35f825932581bc7c9ec811436d2f21a0/hf_xet-1.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6d53df40616f7168abfccff100d232e9d460583b9d86fa4912c24845f192f2b8", size = 3529113, upload-time = "2026-03-13T06:58:58.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339, upload-time = "2026-03-13T06:58:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664, upload-time = "2026-03-13T06:58:34.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422, upload-time = "2026-03-13T06:58:27.472Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847, upload-time = "2026-03-13T06:58:25.989Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843, upload-time = "2026-03-13T06:58:44.59Z" },
+    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -312,32 +372,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.31.4"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/a0/7445e07427a917399db619e3c7383de3cd723c20d3b3a8a527a096c49a44/huggingface_hub-0.31.4.tar.gz", hash = "sha256:5a7bc710b9f9c028aee5b1476867b4ec5c1b92f043cb364d5fdc54354757e4ce", size = 407736, upload-time = "2025-05-19T09:37:13.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/c7/852d4473788cfd7d79b73951244b87a6d75fdac296c90aeb5e85dbb2fb5e/huggingface_hub-0.31.4-py3-none-any.whl", hash = "sha256:4f70704760296cc69b612916056e9845f5490a33782b924fc531767967acc15d", size = 489319, upload-time = "2025-05-19T09:37:11.506Z" },
-]
-
-[[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -439,6 +488,7 @@ dependencies = [
     { name = "mypy" },
     { name = "openai" },
     { name = "optimum", extra = ["onnxruntime"] },
+    { name = "peft" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
@@ -455,15 +505,12 @@ dependencies = [
     { name = "sqlite-utils" },
     { name = "sqlite-vec" },
     { name = "tiktoken" },
+    { name = "torch" },
+    { name = "transformers" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-setuptools" },
     { name = "uvicorn" },
-]
-
-[package.optional-dependencies]
-gpu = [
-    { name = "onnxruntime-gpu" },
 ]
 
 [package.dev-dependencies]
@@ -480,9 +527,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "markdownify", specifier = ">=1.2.2" },
     { name = "mypy", specifier = ">=1.15.0" },
-    { name = "onnxruntime-gpu", marker = "extra == 'gpu'", specifier = ">=1.16.0" },
     { name = "openai", specifier = ">=1.79.0" },
-    { name = "optimum", extras = ["onnxruntime"], specifier = ">=2.0.0" },
+    { name = "optimum", extras = ["onnxruntime"], specifier = ">=2.1.0" },
+    { name = "peft", specifier = ">=0.18.1" },
     { name = "pgvector", specifier = ">=0.4.2" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.2" },
     { name = "pydantic", specifier = ">=2.6.0" },
@@ -499,12 +546,13 @@ requires-dist = [
     { name = "sqlite-utils", specifier = ">=3.38" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
     { name = "tiktoken", specifier = ">=0.9.0" },
+    { name = "torch", specifier = ">=2.8.0" },
+    { name = "transformers", specifier = ">=4.57.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
     { name = "types-setuptools", specifier = ">=80.8.0.20250521" },
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
-provides-extras = ["gpu"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -704,81 +752,77 @@ wheels = [
 
 [[package]]
 name = "nvidia-cublas-cu12"
-version = "12.6.4.1"
+version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/eb/ff4b8c503fa1f1796679dce648854d58751982426e4e4b37d6fce49d259c/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb", size = 393138322, upload-time = "2024-11-20T17:40:25.65Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-cupti-cu12"
-version = "12.6.80"
+version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/60/7b6497946d74bcf1de852a21824d63baad12cd417db4195fc1bfe59db953/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132", size = 8917980, upload-time = "2024-11-20T17:36:04.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/24/120ee57b218d9952c379d1e026c4479c9ece9997a4fb46303611ee48f038/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73", size = 8917972, upload-time = "2024-10-01T16:58:06.036Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-nvrtc-cu12"
-version = "12.6.77"
+version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/2e/46030320b5a80661e88039f59060d1790298b4718944a65a7f2aeda3d9e9/nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53", size = 23650380, upload-time = "2024-10-01T17:00:14.643Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-runtime-cu12"
-version = "12.6.77"
+version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/23/e717c5ac26d26cf39a27fbc076240fad2e3b817e5889d671b67f4f9f49c5/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7", size = 897690, upload-time = "2024-11-20T17:35:30.697Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/62/65c05e161eeddbafeca24dc461f47de550d9fa8a7e04eb213e32b55cfd99/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8", size = 897678, upload-time = "2024-10-01T16:57:33.821Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu12"
-version = "9.5.1.17"
+version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
 ]
 
 [[package]]
 name = "nvidia-cufft-cu12"
-version = "11.3.0.4"
+version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
-    { url = "https://files.pythonhosted.org/packages/60/de/99ec247a07ea40c969d904fc14f3a356b3e2a704121675b75c366b694ee1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca", size = 200221622, upload-time = "2024-10-01T17:03:58.79Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
 ]
 
 [[package]]
 name = "nvidia-cufile-cu12"
-version = "1.11.1.6"
+version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/66/cc9876340ac68ae71b15c743ddb13f8b30d5244af344ec8322b449e35426/nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159", size = 1142103, upload-time = "2024-11-20T17:42:11.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
 ]
 
 [[package]]
 name = "nvidia-curand-cu12"
-version = "10.3.7.77"
+version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/1b/44a01c4e70933637c93e6e1a8063d1e998b50213a6b65ac5a9169c47e98e/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf", size = 56279010, upload-time = "2024-11-20T17:42:50.958Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/aa/2c7ff0b5ee02eaef890c0ce7d4f74bc30901871c5e45dee1ae6d0083cd80/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117", size = 56279000, upload-time = "2024-10-01T17:04:45.274Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
 ]
 
 [[package]]
 name = "nvidia-cusolver-cu12"
-version = "11.7.1.2"
+version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas-cu12" },
@@ -786,58 +830,63 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/81/baba53585da791d043c10084cf9553e074548408e04ae884cfe9193bd484/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6", size = 158229780, upload-time = "2024-10-01T17:05:39.875Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
 ]
 
 [[package]]
 name = "nvidia-cusparse-cu12"
-version = "12.5.4.2"
+version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ac/64c4316ba163e8217a99680c7605f779accffc6a4bcd0c778c12948d3707/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f", size = 216561357, upload-time = "2024-10-01T17:06:29.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
 ]
 
 [[package]]
 name = "nvidia-cusparselt-cu12"
-version = "0.6.3"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796, upload-time = "2024-10-15T21:29:17.709Z" },
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu12"
-version = "2.26.2"
+version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/ca/f42388aed0fddd64ade7493dbba36e1f534d4e6fdbdd355c6a90030ae028/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6", size = 201319755, upload-time = "2025-03-13T00:29:55.296Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.6.85"
+version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/d7/c5383e47c7e9bf1c99d5bd2a8c935af2b6d705ad831a7ec5c97db4d82f4f/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a", size = 19744971, upload-time = "2024-11-20T17:46:53.366Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
 ]
 
 [[package]]
 name = "nvidia-nvtx-cu12"
-version = "12.6.77"
+version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2", size = 89276, upload-time = "2024-11-20T17:38:27.621Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4e/0d0c945463719429b7bd21dece907ad0bde437a2ff12b9b12fee94722ab0/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1", size = 89265, upload-time = "2024-10-01T17:00:38.172Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
 ]
 
 [[package]]
 name = "onnx"
-version = "1.19.1"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
@@ -845,56 +894,23 @@ dependencies = [
     { name = "protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/2f/c619eb65769357e9b6de9212c9a821ab39cd484448e5d6b3fb5fb0a64c6d/onnx-1.19.1.tar.gz", hash = "sha256:737524d6eb3907d3499ea459c6f01c5a96278bb3a0f2ff8ae04786fb5d7f1ed5", size = 12033525, upload-time = "2025-10-10T04:01:34.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/8a/335c03a8683a88a32f9a6bb98899ea6df241a41df64b37b9696772414794/onnx-1.20.1.tar.gz", hash = "sha256:ded16de1df563d51fbc1ad885f2a426f814039d8b5f4feb77febe09c0295ad67", size = 12048980, upload-time = "2026-01-10T01:40:03.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/07/f6c5b2cffef8c29e739616d1415aea22f7b7ef1f19c17f02b7cff71f5498/onnx-1.19.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:3612193a89ddbce5c4e86150869b9258780a82fb8c4ca197723a4460178a6ce9", size = 18327840, upload-time = "2025-10-10T04:00:24.259Z" },
-    { url = "https://files.pythonhosted.org/packages/93/20/0568ebd52730287ae80cac8ac893a7301c793ea1630984e2519ee92b02a9/onnx-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c2fd2f744e7a3880ad0c262efa2edf6d965d0bd02b8f327ec516ad4cb0f2f15", size = 18042539, upload-time = "2025-10-10T04:00:27.693Z" },
-    { url = "https://files.pythonhosted.org/packages/14/fd/cd7a0fd10a04f8cc5ae436b63e0022e236fe51b9dbb8ee6317fd48568c72/onnx-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:485d3674d50d789e0ee72fa6f6e174ab81cb14c772d594f992141bd744729d8a", size = 18218271, upload-time = "2025-10-10T04:00:30.495Z" },
-    { url = "https://files.pythonhosted.org/packages/65/68/cc8b8c05469fe08384b446304ad7e6256131ca0463bf6962366eebec98c0/onnx-1.19.1-cp312-cp312-win32.whl", hash = "sha256:638bc56ff1a5718f7441e887aeb4e450f37a81c6eac482040381b140bd9ba601", size = 16345111, upload-time = "2025-10-10T04:00:34.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5e/d1cb16693598a512c2cf9ffe0841d8d8fd2c83ae8e889efd554f5aa427cf/onnx-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:bc7e2e4e163e679721e547958b5a7db875bf822cad371b7c1304aa4401a7c7a4", size = 16465621, upload-time = "2025-10-10T04:00:39.107Z" },
-    { url = "https://files.pythonhosted.org/packages/90/32/da116cc61fdef334782aa7f87a1738431dd1af1a5d1a44bd95d6d51ad260/onnx-1.19.1-cp312-cp312-win_arm64.whl", hash = "sha256:17c215b1c0f20fe93b4cbe62668247c1d2294b9bc7f6be0ca9ced28e980c07b7", size = 16437505, upload-time = "2025-10-10T04:00:42.255Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/b8/ab1fdfe2e8502f4dc4289fc893db35816bd20d080d8370f86e74dda5f598/onnx-1.19.1-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:4e5f938c68c4dffd3e19e4fd76eb98d298174eb5ebc09319cdd0ec5fe50050dc", size = 18327815, upload-time = "2025-10-10T04:00:45.682Z" },
-    { url = "https://files.pythonhosted.org/packages/04/40/eb875745a4b92aea10e5e32aa2830f409c4d7b6f7b48ca1c4eaad96636c5/onnx-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:86e20a5984b017feeef2dbf4ceff1c7c161ab9423254968dd77d3696c38691d0", size = 18041464, upload-time = "2025-10-10T04:00:48.557Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8e/8586135f40dbe4989cec4d413164bc8fc5c73d37c566f33f5ea3a7f2b6f6/onnx-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d9c467f0f29993c12f330736af87972f30adb8329b515f39d63a0db929cb2c", size = 18218244, upload-time = "2025-10-10T04:00:51.891Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b5/4201254b8683129db5da3fb55aa1f7e56d0a8d45c66ce875dec21ca1ff25/onnx-1.19.1-cp313-cp313-win32.whl", hash = "sha256:65eee353a51b4e4ca3e797784661e5376e2b209f17557e04921eac9166a8752e", size = 16345330, upload-time = "2025-10-10T04:00:54.858Z" },
-    { url = "https://files.pythonhosted.org/packages/69/67/c6d239afbcdbeb6805432969b908b5c9f700c96d332b34e3f99518d76caf/onnx-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:c3bc87e38b53554b1fc9ef7b275c81c6f5c93c90a91935bb0aa8d4d498a6d48e", size = 16465567, upload-time = "2025-10-10T04:00:57.893Z" },
-    { url = "https://files.pythonhosted.org/packages/99/fe/89f1e40f5bc54595ff0dcf5391ce19e578b528973ccc74dd99800196d30d/onnx-1.19.1-cp313-cp313-win_arm64.whl", hash = "sha256:e41496f400afb980ec643d80d5164753a88a85234fa5c06afdeebc8b7d1ec252", size = 16437562, upload-time = "2025-10-10T04:01:00.703Z" },
-    { url = "https://files.pythonhosted.org/packages/86/43/b186ccbc8fe7e93643a6a6d40bbf2bb6ce4fb9469bbd3453c77e270c50ad/onnx-1.19.1-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:5f6274abf0fd74e80e78ecbb44bd44509409634525c89a9b38276c8af47dc0a2", size = 18355703, upload-time = "2025-10-10T04:01:03.735Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f1/22ee4d8b8f9fa4cb1d1b9579da3b4b5187ddab33846ec5ac744af02c0e2b/onnx-1.19.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07dcd4d83584eb4bf8f21ac04c82643712e5e93ac2a0ed10121ec123cb127e1e", size = 18047830, upload-time = "2025-10-10T04:01:06.552Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a4/8f3d51e3a095d42cdf2039a590cff06d024f2a10efbd0b1a2a6b3825f019/onnx-1.19.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1975860c3e720db25d37f1619976582828264bdcc64fa7511c321ac4fc01add3", size = 18221126, upload-time = "2025-10-10T04:01:09.77Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/0d/f9d6c2237083f1aac14b37f0b03b0d81f1147a8e2af0c3828165e0a6a67b/onnx-1.19.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9807d0e181f6070ee3a6276166acdc571575d1bd522fc7e89dba16fd6e7ffed9", size = 16465560, upload-time = "2025-10-10T04:01:13.212Z" },
-    { url = "https://files.pythonhosted.org/packages/36/70/8418a58faa7d606d6a92cab69ae8d361b3b3969bf7e7e9a65a86d5d1b674/onnx-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6ee83e6929d75005482d9f304c502ac7c9b8d6db153aa6b484dae74d0f28570", size = 18042812, upload-time = "2025-10-10T04:01:15.919Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4c/4b17e82f91ab9aa07ff595771e935ca73547b035030dc5f5a76e63fbfea9/onnx-1.20.1-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:1d923bb4f0ce1b24c6859222a7e6b2f123e7bfe7623683662805f2e7b9e95af2", size = 17903547, upload-time = "2026-01-10T01:39:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/1bfa100a9cb3f2d3d5f2f05f52f7e60323b0e20bb0abace1ae64dbc88f25/onnx-1.20.1-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddc0b7d8b5a94627dc86c533d5e415af94cbfd103019a582669dad1f56d30281", size = 17412021, upload-time = "2026-01-10T01:39:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/d3fec0dcf9a7a99e7368112d9c765154e81da70fcba1e3121131a45c245b/onnx-1.20.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9336b6b8e6efcf5c490a845f6afd7e041c89a56199aeda384ed7d58fb953b080", size = 17510450, upload-time = "2026-01-10T01:39:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a7/edce1403e05a46e59b502fae8e3350ceeac5841f8e8f1561e98562ed9b09/onnx-1.20.1-cp312-abi3-win32.whl", hash = "sha256:564c35a94811979808ab5800d9eb4f3f32c12daedba7e33ed0845f7c61ef2431", size = 16238216, upload-time = "2026-01-10T01:39:39.46Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c7/8690c81200ae652ac550c1df52f89d7795e6cc941f3cb38c9ef821419e80/onnx-1.20.1-cp312-abi3-win_amd64.whl", hash = "sha256:9fe7f9a633979d50984b94bda8ceb7807403f59a341d09d19342dc544d0ca1d5", size = 16389207, upload-time = "2026-01-10T01:39:41.955Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a0/4fb0e6d36eaf079af366b2c1f68bafe92df6db963e2295da84388af64abc/onnx-1.20.1-cp312-abi3-win_arm64.whl", hash = "sha256:21d747348b1c8207406fa2f3e12b82f53e0d5bb3958bcd0288bd27d3cb6ebb00", size = 16344155, upload-time = "2026-01-10T01:39:45.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/bb/715fad292b255664f0e603f1b2ef7bf2b386281775f37406beb99fa05957/onnx-1.20.1-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:29197b768f5acdd1568ddeb0a376407a2817844f6ac1ef8c8dd2d974c9ab27c3", size = 17912296, upload-time = "2026-01-10T01:39:48.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c3/541af12c3d45e159a94ee701100ba9e94b7bd8b7a8ac5ca6838569f894f8/onnx-1.20.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f0371aa67f51917a09cc829ada0f9a79a58f833449e03d748f7f7f53787c43c", size = 17416925, upload-time = "2026-01-10T01:39:50.82Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/d5660a7d2ddf14f531ca66d409239f543bb290277c3f14f4b4b78e32efa3/onnx-1.20.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be1e5522200b203b34327b2cf132ddec20ab063469476e1f5b02bb7bd259a489", size = 17515602, upload-time = "2026-01-10T01:39:54.132Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b4/47225ab2a92562eff87ba9a1a028e3535d659a7157d7cde659003998b8e3/onnx-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:15c815313bbc4b2fdc7e4daeb6e26b6012012adc4d850f4e3b09ed327a7ea92a", size = 16395729, upload-time = "2026-01-10T01:39:57.577Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/7d/1bbe626ff6b192c844d3ad34356840cc60fca02e2dea0db95e01645758b1/onnx-1.20.1-cp313-cp313t-win_arm64.whl", hash = "sha256:eb335d7bcf9abac82a0d6a0fda0363531ae0b22cfd0fc6304bff32ee29905def", size = 16348968, upload-time = "2026-01-10T01:40:00.491Z" },
 ]
 
 [[package]]
 name = "onnxruntime"
-version = "1.23.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
-    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
-]
-
-[[package]]
-name = "onnxruntime-gpu"
 version = "1.24.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -905,14 +921,25 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/fa/58ceca812214c9c1a286407c376e42e0b7de3e2c6e14b61cdf3caf6d6d9c/onnxruntime_gpu-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:537bdd6d95006a9200ae81f2e73ba9e621e723fdf0deb5901e2e62fb2cccf876", size = 252756089, upload-time = "2026-03-05T16:35:46.004Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/07/2f36920b513bd8939e25591153e37d9cfda94115bd119f2874da0750fce2/onnxruntime_gpu-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:d72065b3ab5fdaef74d8b6b8f39b7ce20d89731610e3e63cb40e997d3dce177e", size = 207197001, upload-time = "2026-03-05T16:40:05.691Z" },
-    { url = "https://files.pythonhosted.org/packages/49/57/9e6206dac76e08f028d2ae95f2ab1b3a7c3317fb6c0374a530aad48dab5c/onnxruntime_gpu-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3242a70010934e5bb0aeaa9dde4c25c6c2da577b55c6308c0caa828ba3b7be23", size = 252753349, upload-time = "2026-03-05T16:35:58.09Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ae/f0be395602c13a3a8d22fa6632133550a64536c58bc3623abbba5d0a575e/onnxruntime_gpu-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:a423b164dbc26cb7f8736367b11698c2a7294748d3c144c39542ecac28d225c9", size = 207197331, upload-time = "2026-03-05T16:40:14.944Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/af/a64c9789769d8d7fabc6d35dcce2f2897b2d9e0fe113044efc2903f7cd07/onnxruntime_gpu-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9696d54974a1313ef0d87f4cbd04f9abfd13839194638d52bb5967a15615341d", size = 252762923, upload-time = "2026-03-05T16:36:10.043Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/bb/1cf7dffac2fb01e8de9f0882438165f7543f0aab57f86d1f587e6faa8528/onnxruntime_gpu-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8ca744f40b33380bc9136988213e574c927d2b919ed42149977e006b138f74f", size = 252754914, upload-time = "2026-03-05T16:36:30.739Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/39/3949d56103bd9cd9381de59b060f9bce8dc2c7363f465bf207ebd0c7a5d0/onnxruntime_gpu-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:c60c44e2b388720e6670a948b52626f3d089e960ef7da66e4fa6b2b33a11116f", size = 209599131, upload-time = "2026-03-05T16:40:24.074Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/60/51bfbcf2d0540dbfa426a73a9b80046b71a63de7303d16c0f2682c8edfd2/onnxruntime_gpu-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29048407a2398361d93de5537c2d2079d79d720337a0743d4a2cc28db981e776", size = 252764115, upload-time = "2026-03-05T16:36:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
 ]
 
 [[package]]
@@ -936,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "optimum"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -945,9 +972,9 @@ dependencies = [
     { name = "torch" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2e/45e61beac8b53514f3b658ee54e0c31c46bd8110bfed20cc15a670c198c6/optimum-2.0.0.tar.gz", hash = "sha256:4e59e51128ed6311b615dcee84c1559702d82cbd4bae18fd3031f4fe927c484c", size = 126935, upload-time = "2025-10-09T10:56:14.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/69/e1e9fe4d54f6b1b90cc278d6da74dd90eb4d9fd9228882886d7c275712e2/optimum-2.1.0.tar.gz", hash = "sha256:0a2a13f91500e41d34863ffdb08fcb886b3ce68a84a386e59653e3064a45dd4b", size = 125896, upload-time = "2025-12-19T10:47:18.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/c1/42d1929b36b977613940d2a36cba077da7b8152492788bf5fad9de27dc3f/optimum-2.0.0-py3-none-any.whl", hash = "sha256:23bc60a679db676b578c7692bab7a62af31e27fe648fdc45d2bd4d3aabfcb2d9", size = 162279, upload-time = "2025-10-09T10:56:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/c409ed937331839fdadc03cef6ebd19982bf3834711134db8898eeb31585/optimum-2.1.0-py3-none-any.whl", hash = "sha256:bc3af32e1236a9b2c2ca1d27ed9d3ab1b6591e24c6bcd47f9671a8198a30ea88", size = 161231, upload-time = "2025-12-19T10:47:17.054Z" },
 ]
 
 [package.optional-dependencies]
@@ -957,16 +984,16 @@ onnxruntime = [
 
 [[package]]
 name = "optimum-onnx"
-version = "0.0.3"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "onnx" },
     { name = "optimum" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/51/6d1cc74f3548a3cb347439bc26e0b3964df160e9cc1f688e192f6abca2d7/optimum_onnx-0.0.3.tar.gz", hash = "sha256:2e5f67a3441a3c152b89db5214dd1bd96976d96cb433afbbaba6b86293c02046", size = 163652, upload-time = "2025-10-17T06:33:55.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/da/3a0073af8f436d72c1e4d9c655c00628b857bd1d9ccc101d35301d5bb2df/optimum_onnx-0.1.0.tar.gz", hash = "sha256:182c54b25eddaded1618af7b58516da34749393a987ec7111f74677f249676f9", size = 165531, upload-time = "2025-12-23T14:20:18.97Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/cd/e10e57554e97853182aacca1eb00352b2e4b8479eb3100291d5f6327db72/optimum_onnx-0.0.3-py3-none-any.whl", hash = "sha256:d3dc1bb9ac7f3255bd85900b91e0914c18ac99ce65c8ba7b08f42ebdeb0cd44c", size = 192293, upload-time = "2025-10-17T06:33:54.617Z" },
+    { url = "https://files.pythonhosted.org/packages/41/89/4be9d226bc74fd0eb405d1efea62e86d6f0f31841dae9c5898ee12eb482f/optimum_onnx-0.1.0-py3-none-any.whl", hash = "sha256:0301ec7a6ec5c77a57581e9970d380a6dc104bdb8f15b282e05af40d829c2eda", size = 194155, upload-time = "2025-12-23T14:20:17.741Z" },
 ]
 
 [package.optional-dependencies]
@@ -981,6 +1008,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "peft"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/48/147b3ea999560b40a34fd78724c7777aa9d18409c2250bdcaf9c4f2db7fc/peft-0.18.1.tar.gz", hash = "sha256:2dd0d6bfce936d1850e48aaddbd250941c5c02fc8ef3237cd8fd5aac35e0bae2", size = 635030, upload-time = "2026-01-09T13:08:01.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/14/b4e3f574acf349ae6f61f9c000a77f97a3b315b4bb6ad03791e79ae4a568/peft-0.18.1-py3-none-any.whl", hash = "sha256:0bf06847a3551e3019fc58c440cffc9a6b73e6e2962c95b52e224f77bbdb50f1", size = 556960, upload-time = "2026-01-09T13:07:55.865Z" },
 ]
 
 [[package]]
@@ -1047,17 +1095,45 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.1"
+version = "7.34.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/03/a1440979a3f74f16cab3b75b0da1a1a7f922d56a8ddea96092391998edc0/protobuf-6.33.1.tar.gz", hash = "sha256:97f65757e8d09870de6fd973aeddb92f85435607235d20b2dfed93405d00c85b", size = 443432, upload-time = "2025-11-13T16:44:18.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/00/04a2ab36b70a52d0356852979e08b44edde0435f2115dc66e25f2100f3ab/protobuf-7.34.0.tar.gz", hash = "sha256:3871a3df67c710aaf7bb8d214cc997342e63ceebd940c8c7fc65c9b3d697591a", size = 454726, upload-time = "2026-02-27T00:30:25.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/f1/446a9bbd2c60772ca36556bac8bfde40eceb28d9cc7838755bc41e001d8f/protobuf-6.33.1-cp310-abi3-win32.whl", hash = "sha256:f8d3fdbc966aaab1d05046d0240dd94d40f2a8c62856d41eaa141ff64a79de6b", size = 425593, upload-time = "2025-11-13T16:44:06.275Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/79/8780a378c650e3df849b73de8b13cf5412f521ca2ff9b78a45c247029440/protobuf-6.33.1-cp310-abi3-win_amd64.whl", hash = "sha256:923aa6d27a92bf44394f6abf7ea0500f38769d4b07f4be41cb52bd8b1123b9ed", size = 436883, upload-time = "2025-11-13T16:44:09.222Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/93/26213ff72b103ae55bb0d73e7fb91ea570ef407c3ab4fd2f1f27cac16044/protobuf-6.33.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:fe34575f2bdde76ac429ec7b570235bf0c788883e70aee90068e9981806f2490", size = 427522, upload-time = "2025-11-13T16:44:10.475Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/32/df4a35247923393aa6b887c3b3244a8c941c32a25681775f96e2b418f90e/protobuf-6.33.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:f8adba2e44cde2d7618996b3fc02341f03f5bc3f2748be72dc7b063319276178", size = 324445, upload-time = "2025-11-13T16:44:11.869Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d0/d796e419e2ec93d2f3fa44888861c3f88f722cde02b7c3488fcc6a166820/protobuf-6.33.1-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:0f4cf01222c0d959c2b399142deb526de420be8236f22c71356e2a544e153c53", size = 339161, upload-time = "2025-11-13T16:44:12.778Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/2a/3c5f05a4af06649547027d288747f68525755de692a26a7720dced3652c0/protobuf-6.33.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:8fd7d5e0eb08cd5b87fd3df49bc193f5cfd778701f47e11d127d0afc6c39f1d1", size = 323171, upload-time = "2025-11-13T16:44:14.035Z" },
-    { url = "https://files.pythonhosted.org/packages/08/b4/46310463b4f6ceef310f8348786f3cff181cea671578e3d9743ba61a459e/protobuf-6.33.1-py3-none-any.whl", hash = "sha256:d595a9fd694fdeb061a62fbe10eb039cc1e444df81ec9bb70c7fc59ebcb1eafa", size = 170477, upload-time = "2025-11-13T16:44:17.633Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c4/6322ab5c8f279c4c358bc14eb8aefc0550b97222a39f04eb3c1af7a830fa/protobuf-7.34.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e329966799f2c271d5e05e236459fe1cbfdb8755aaa3b0914fa60947ddea408", size = 429248, upload-time = "2026-02-27T00:30:14.924Z" },
+    { url = "https://files.pythonhosted.org/packages/45/99/b029bbbc61e8937545da5b79aa405ab2d9cf307a728f8c9459ad60d7a481/protobuf-7.34.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:9d7a5005fb96f3c1e64f397f91500b0eb371b28da81296ae73a6b08a5b76cdd6", size = 325753, upload-time = "2026-02-27T00:30:17.247Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/79/09f02671eb75b251c5550a1c48e7b3d4b0623efd7c95a15a50f6f9fc1e2e/protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4a72a8ec94e7a9f7ef7fe818ed26d073305f347f8b3b5ba31e22f81fd85fca02", size = 340200, upload-time = "2026-02-27T00:30:18.672Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/57/89727baef7578897af5ed166735ceb315819f1c184da8c3441271dbcfde7/protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:964cf977e07f479c0697964e83deda72bcbc75c3badab506fb061b352d991b01", size = 324268, upload-time = "2026-02-27T00:30:20.088Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3e/38ff2ddee5cc946f575c9d8cc822e34bde205cf61acf8099ad88ef19d7d2/protobuf-7.34.0-cp310-abi3-win32.whl", hash = "sha256:f791ec509707a1d91bd02e07df157e75e4fb9fbdad12a81b7396201ec244e2e3", size = 426628, upload-time = "2026-02-27T00:30:21.555Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/71/7c32eaf34a61a1bae1b62a2ac4ffe09b8d1bb0cf93ad505f42040023db89/protobuf-7.34.0-cp310-abi3-win_amd64.whl", hash = "sha256:9f9079f1dde4e32342ecbd1c118d76367090d4aaa19da78230c38101c5b3dd40", size = 437901, upload-time = "2026-02-27T00:30:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e7/14dc9366696dcb53a413449881743426ed289d687bcf3d5aee4726c32ebb/protobuf-7.34.0-py3-none-any.whl", hash = "sha256:e3b914dd77fa33fa06ab2baa97937746ab25695f389869afdf03e81f34e45dc7", size = 170716, upload-time = "2026-02-27T00:30:23.994Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1202,15 +1278,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234, upload-time = "2025-04-18T16:44:48.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356, upload-time = "2025-04-18T16:44:46.617Z" },
-]
-
-[[package]]
-name = "pyreadline3"
-version = "3.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
 
 [[package]]
@@ -1675,34 +1742,36 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.21.1"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/76/5ac0c97f1117b91b7eb7323dcd61af80d72f790b4df71249a7850c195f30/tokenizers-0.21.1.tar.gz", hash = "sha256:a1bb04dc5b448985f86ecd4b05407f5a8d97cb2c0532199b2a302a604a0165ab", size = 343256, upload-time = "2025-03-13T10:51:18.189Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/1f/328aee25f9115bf04262e8b4e5a2050b7b7cf44b59c74e982db7270c7f30/tokenizers-0.21.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e78e413e9e668ad790a29456e677d9d3aa50a9ad311a40905d6861ba7692cf41", size = 2780767, upload-time = "2025-03-13T10:51:09.459Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/1a/4526797f3719b0287853f12c5ad563a9be09d446c44ac784cdd7c50f76ab/tokenizers-0.21.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:cd51cd0a91ecc801633829fcd1fda9cf8682ed3477c6243b9a095539de4aecf3", size = 2650555, upload-time = "2025-03-13T10:51:07.692Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/7a/a209b29f971a9fdc1da86f917fe4524564924db50d13f0724feed37b2a4d/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28da6b72d4fb14ee200a1bd386ff74ade8992d7f725f2bde2c495a9a98cf4d9f", size = 2937541, upload-time = "2025-03-13T10:50:56.679Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/1e/b788b50ffc6191e0b1fc2b0d49df8cff16fe415302e5ceb89f619d12c5bc/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:34d8cfde551c9916cb92014e040806122295a6800914bab5865deb85623931cf", size = 2819058, upload-time = "2025-03-13T10:50:59.525Z" },
-    { url = "https://files.pythonhosted.org/packages/36/aa/3626dfa09a0ecc5b57a8c58eeaeb7dd7ca9a37ad9dd681edab5acd55764c/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aaa852d23e125b73d283c98f007e06d4595732104b65402f46e8ef24b588d9f8", size = 3133278, upload-time = "2025-03-13T10:51:04.678Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/4d/8fbc203838b3d26269f944a89459d94c858f5b3f9a9b6ee9728cdcf69161/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a21a15d5c8e603331b8a59548bbe113564136dc0f5ad8306dd5033459a226da0", size = 3144253, upload-time = "2025-03-13T10:51:01.261Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/1b/2bd062adeb7c7511b847b32e356024980c0ffcf35f28947792c2d8ad2288/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2fdbd4c067c60a0ac7eca14b6bd18a5bebace54eb757c706b47ea93204f7a37c", size = 3398225, upload-time = "2025-03-13T10:51:03.243Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/63/38be071b0c8e06840bc6046991636bcb30c27f6bb1e670f4f4bc87cf49cc/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dd9a0061e403546f7377df940e866c3e678d7d4e9643d0461ea442b4f89e61a", size = 3038874, upload-time = "2025-03-13T10:51:06.235Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/83/afa94193c09246417c23a3c75a8a0a96bf44ab5630a3015538d0c316dd4b/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:db9484aeb2e200c43b915a1a0150ea885e35f357a5a8fabf7373af333dcc8dbf", size = 9014448, upload-time = "2025-03-13T10:51:10.927Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b3/0e1a37d4f84c0f014d43701c11eb8072704f6efe8d8fc2dcdb79c47d76de/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:ed248ab5279e601a30a4d67bdb897ecbe955a50f1e7bb62bd99f07dd11c2f5b6", size = 8937877, upload-time = "2025-03-13T10:51:12.688Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/33/ff08f50e6d615eb180a4a328c65907feb6ded0b8f990ec923969759dc379/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:9ac78b12e541d4ce67b4dfd970e44c060a2147b9b2a21f509566d556a509c67d", size = 9186645, upload-time = "2025-03-13T10:51:14.723Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/aa/8ae85f69a9f6012c6f8011c6f4aa1c96154c816e9eea2e1b758601157833/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e5a69c1a4496b81a5ee5d2c1f3f7fbdf95e90a0196101b0ee89ed9956b8a168f", size = 9384380, upload-time = "2025-03-13T10:51:16.526Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5b/a5d98c89f747455e8b7a9504910c865d5e51da55e825a7ae641fb5ff0a58/tokenizers-0.21.1-cp39-abi3-win32.whl", hash = "sha256:1039a3a5734944e09de1d48761ade94e00d0fa760c0e0551151d4dd851ba63e3", size = 2239506, upload-time = "2025-03-13T10:51:20.643Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b6/072a8e053ae600dcc2ac0da81a23548e3b523301a442a6ca900e92ac35be/tokenizers-0.21.1-cp39-abi3-win_amd64.whl", hash = "sha256:0f0dcbcc9f6e13e675a66d7a5f2f225a736745ce484c1a4e07476a89ccdad382", size = 2435481, upload-time = "2025-03-13T10:51:19.243Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
 name = "torch"
-version = "2.7.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
@@ -1720,6 +1789,7 @@ dependencies = [
     { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
@@ -1727,18 +1797,33 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/5e/ac759f4c0ab7c01feffa777bd68b43d2ac61560a9770eeac074b450f81d4/torch-2.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:36a6368c7ace41ad1c0f69f18056020b6a5ca47bedaca9a2f3b578f5a104c26c", size = 99013250, upload-time = "2025-04-23T14:35:15.589Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/58/2d245b6f1ef61cf11dfc4aceeaacbb40fea706ccebac3f863890c720ab73/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:15aab3e31c16feb12ae0a88dba3434a458874636f360c567caa6a91f6bfba481", size = 865042157, upload-time = "2025-04-23T14:32:56.011Z" },
-    { url = "https://files.pythonhosted.org/packages/44/80/b353c024e6b624cd9ce1d66dcb9d24e0294680f95b369f19280e241a0159/torch-2.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:f56d4b2510934e072bab3ab8987e00e60e1262fb238176168f5e0c43a1320c6d", size = 212482262, upload-time = "2025-04-23T14:35:03.527Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8d/b2939e5254be932db1a34b2bd099070c509e8887e0c5a90c498a917e4032/torch-2.7.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:30b7688a87239a7de83f269333651d8e582afffce6f591fff08c046f7787296e", size = 68574294, upload-time = "2025-04-23T14:34:47.098Z" },
-    { url = "https://files.pythonhosted.org/packages/14/24/720ea9a66c29151b315ea6ba6f404650834af57a26b2a04af23ec246b2d5/torch-2.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:868ccdc11798535b5727509480cd1d86d74220cfdc42842c4617338c1109a205", size = 99015553, upload-time = "2025-04-23T14:34:41.075Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/27/285a8cf12bd7cd71f9f211a968516b07dcffed3ef0be585c6e823675ab91/torch-2.7.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b52347118116cf3dff2ab5a3c3dd97c719eb924ac658ca2a7335652076df708", size = 865046389, upload-time = "2025-04-23T14:32:01.16Z" },
-    { url = "https://files.pythonhosted.org/packages/74/c8/2ab2b6eadc45554af8768ae99668c5a8a8552e2012c7238ded7e9e4395e1/torch-2.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:434cf3b378340efc87c758f250e884f34460624c0523fe5c9b518d205c91dd1b", size = 212490304, upload-time = "2025-04-23T14:33:57.108Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fd/74ba6fde80e2b9eef4237fe668ffae302c76f0e4221759949a632ca13afa/torch-2.7.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:edad98dddd82220465b106506bb91ee5ce32bd075cddbcf2b443dfaa2cbd83bf", size = 68856166, upload-time = "2025-04-23T14:34:04.012Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/b4/8df3f9fe6bdf59e56a0e538592c308d18638eb5f5dc4b08d02abb173c9f0/torch-2.7.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a885fc25afefb6e6eb18a7d1e8bfa01cc153e92271d980a49243b250d5ab6d9", size = 99091348, upload-time = "2025-04-23T14:33:48.975Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/f5/0bd30e9da04c3036614aa1b935a9f7e505a9e4f1f731b15e165faf8a4c74/torch-2.7.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:176300ff5bc11a5f5b0784e40bde9e10a35c4ae9609beed96b4aeb46a27f5fae", size = 865104023, upload-time = "2025-04-23T14:30:40.537Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/2235d0c3012c596df1c8d39a3f4afc1ee1b6e318d469eda4c8bb68566448/torch-2.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:d0ca446a93f474985d81dc866fcc8dccefb9460a29a456f79d99c29a78a66993", size = 212750916, upload-time = "2025-04-23T14:32:22.91Z" },
-    { url = "https://files.pythonhosted.org/packages/90/48/7e6477cf40d48cc0a61fa0d41ee9582b9a316b12772fcac17bc1a40178e7/torch-2.7.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:27f5007bdf45f7bb7af7f11d1828d5c2487e030690afb3d89a651fd7036a390e", size = 68575074, upload-time = "2025-04-23T14:32:38.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
+    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
+    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
 ]
 
 [[package]]
@@ -1755,7 +1840,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.51.3"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1769,22 +1854,21 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/11/7414d5bc07690002ce4d7553602107bf969af85144bbd02830f9fb471236/transformers-4.51.3.tar.gz", hash = "sha256:e292fcab3990c6defe6328f0f7d2004283ca81a7a07b2de9a46d67fd81ea1409", size = 8941266, upload-time = "2025-04-14T08:15:00.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/b6/5257d04ae327b44db31f15cce39e6020cc986333c715660b1315a9724d82/transformers-4.51.3-py3-none-any.whl", hash = "sha256:fd3279633ceb2b777013234bbf0b4f5c2d23c4626b05497691f00cfda55e8a83", size = 10383940, upload-time = "2025-04-14T08:13:43.023Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]
 name = "triton"
-version = "3.3.0"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/53/ce18470914ab6cfbec9384ee565d23c4d1c55f0548160b1c7b33000b11fd/triton-3.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b68c778f6c4218403a6bd01be7484f6dc9e20fe2083d22dd8aef33e3b87a10a3", size = 156504509, upload-time = "2025-04-09T20:27:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/74/4bf2702b65e93accaa20397b74da46fb7a0356452c1bb94dbabaf0582930/triton-3.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47bc87ad66fa4ef17968299acacecaab71ce40a238890acc6ad197c3abe2b8f1", size = 156516468, upload-time = "2025-04-09T20:27:48.196Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/93/f28a696fa750b9b608baa236f8225dd3290e5aff27433b06143adc025961/triton-3.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce4700fc14032af1e049005ae94ba908e71cd6c2df682239aed08e49bc71b742", size = 156580729, upload-time = "2025-04-09T20:27:55.424Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Added the option in include/exclude vector indexes from the sync (Fixes #87 )
Added support for Jina v5 embeddings models and added GPU support for local embedding models in general (Fixes #82 )
Added scripts for dumping articles to jsonl and embedding the contents of a jsonl, which enables us to offload computation to UCloud if we want (Fixes #83 )
Did extensive refactoring on the embeddings.py file to enable all of these changes.