### PR TITLE
Added batch search routes

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -182,7 +182,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/text-search/batch:
+  /api/text-search/indexes/{index_name}/batch:
     post:
       tags:
       - lex-db
@@ -192,13 +192,11 @@ paths:
       operationId: batch_fulltext_search
       parameters:
       - name: index_name
-        in: query
+        in: path
         required: true
         schema:
           type: string
-          description: Name of the vector index to search chunks in
           title: Index Name
-        description: Name of the vector index to search chunks in
       requestBody:
         required: true
         content:
@@ -213,7 +211,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RetrievalResult'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RetrievalResult'
                 title: Response Batch Fulltext Search
         '422':
           description: Validation Error
@@ -517,6 +517,16 @@ components:
         score:
           type: number
           title: Score
+        url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Url
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
       type: object
       required:
       - id
@@ -643,6 +653,16 @@ components:
         distance:
           type: number
           title: Distance
+        url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Url
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
       type: object
       required:
       - id_in_index

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -527,6 +527,11 @@ components:
           - type: string
           - type: 'null'
           title: Title
+        changed_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Changed At
       type: object
       required:
       - id
@@ -663,6 +668,11 @@ components:
           - type: string
           - type: 'null'
           title: Title
+        changed_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Changed At
       type: object
       required:
       - id_in_index

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -73,14 +73,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/vector-search/indexes/{index_name}/batch:
+    post:
+      tags:
+      - lex-db
+      summary: Batch search a vector index for similar content to multiple query texts
+      description: Search a vector index for similar content to multiple query texts
+        in batch.
+      operationId: batch_vector_search
+      parameters:
+      - name: index_name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Index Name
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchVectorSearchRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VectorSearchResults'
+                title: Response Batch Vector Search
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/hybrid-search/indexes/{index_name}/query:
     post:
       tags:
       - lex-db
-      summary: Hybrid search combining semantic and keyword search with RRF fusion
+      summary: '[DEPRECATED] Hybrid search combining semantic and keyword search with
+        RRF fusion. Use batch semantic and/or batch fulltext search instead.'
       description: Perform hybrid search using RRF fusion of semantic and keyword
         search.
       operationId: hybrid_search
+      deprecated: true
       parameters:
       - name: index_name
         in: path
@@ -111,10 +150,12 @@ paths:
     post:
       tags:
       - lex-db
-      summary: HyDE search using LLM-generated hypothetical document
+      summary: '[DEPRECATED] HyDE search using LLM-generated hypothetical document.
+        Use batch semantic search instead.'
       description: 'Perform HyDE search: generate hypothetical document, embed it,
         and search.'
       operationId: hyde_search
+      deprecated: true
       parameters:
       - name: index_name
         in: path
@@ -135,6 +176,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VectorSearchResults'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/text-search/batch:
+    post:
+      tags:
+      - lex-db
+      summary: Batch fulltext search across vector index chunks
+      description: Perform batch fulltext search on vector index chunks using Danish
+        FTS.
+      operationId: batch_fulltext_search
+      parameters:
+      - name: index_name
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Name of the vector index to search chunks in
+          title: Index Name
+        description: Name of the vector index to search chunks in
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchFulltextSearchRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RetrievalResult'
+                title: Response Batch Fulltext Search
         '422':
           description: Validation Error
           content:
@@ -270,6 +350,43 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
+    BatchFulltextSearchRequest:
+      properties:
+        queries:
+          items:
+            type: string
+          type: array
+          title: Queries
+        top_k:
+          type: integer
+          title: Top K
+          default: 50
+      type: object
+      required:
+      - queries
+      title: BatchFulltextSearchRequest
+      description: Batch fulltext search request model.
+    BatchVectorSearchRequest:
+      properties:
+        queries:
+          items:
+            prefixItems:
+            - type: string
+            - $ref: '#/components/schemas/TextType'
+            type: array
+            maxItems: 2
+            minItems: 2
+          type: array
+          title: Queries
+        top_k:
+          type: integer
+          title: Top K
+          default: 5
+      type: object
+      required:
+      - queries
+      title: BatchVectorSearchRequest
+      description: Batch vector search request model.
     BenchmarkEmbeddingsRequest:
       properties:
         model_choice:
@@ -369,7 +486,8 @@ components:
       required:
       - query_text
       title: HybridSearchRequest
-      description: Hybrid search request model.
+      description: "Hybrid search request model.\n\n.. deprecated::\n    Use batch\
+        \ semantic search and/or batch fulltext search endpoints instead."
     HybridSearchResults:
       properties:
         results:
@@ -467,6 +585,12 @@ components:
       - limit
       title: SearchResults
       description: Results of a search.
+    TextType:
+      type: string
+      enum:
+      - query
+      - passage
+      title: TextType
     ValidationError:
       properties:
         loc:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -530,6 +530,7 @@ components:
         changed_at:
           anyOf:
           - type: string
+            format: date-time
           - type: 'null'
           title: Changed At
       type: object
@@ -671,6 +672,7 @@ components:
         changed_at:
           anyOf:
           - type: string
+            format: date-time
           - type: 'null'
           title: Changed At
       type: object

--- a/src/lex_db/advanced_search.py
+++ b/src/lex_db/advanced_search.py
@@ -131,6 +131,8 @@ def fuse_results_rrf(
                 chunk_sequence=res_list[0].chunk_sequence,
                 chunk_text=res_list[0].chunk_text,
                 score=score,
+                url=res_list[0].url,
+                title=res_list[0].title,
             )
         )
 
@@ -309,6 +311,8 @@ def hybrid_search(
                     chunk_sequence=r.chunk_seq,
                     chunk_text=r.chunk_text,
                     score=r.distance,
+                    url=r.url,
+                    title=r.title,
                 )
                 for r in res.results
             ]

--- a/src/lex_db/api/routes.py
+++ b/src/lex_db/api/routes.py
@@ -257,16 +257,14 @@ async def hyde_search(
 
 
 @router.post(
-    "/text-search/batch",
+    "/text-search/indexes/{index_name}/batch",
     operation_id="batch_fulltext_search",
     summary="Batch fulltext search across vector index chunks",
 )
 async def batch_fulltext_search(
+    index_name: str,
     request: BatchFulltextSearchRequest,
-    index_name: str = Query(
-        ..., description="Name of the vector index to search chunks in"
-    ),
-) -> list[RetrievalResult]:
+) -> list[list[RetrievalResult]]:
     """Perform batch fulltext search on vector index chunks using Danish FTS."""
     try:
         logger.info(
@@ -277,17 +275,21 @@ async def batch_fulltext_search(
             meta = get_vector_index_metadata(conn, index_name)
             if not meta:
                 raise HTTPException(
-                    status_code=404, detail=f"Vector index '{index_name}' not found"
+                    status_code=404,
+                    detail=f"Vector index '{index_name}' not found",
                 )
 
-            results = search_fts_chunks(
-                db_conn=conn,
-                vector_index_name=index_name,
-                queries=request.queries,
-                top_k=request.top_k,
-            )
+            results_per_query: list[list[RetrievalResult]] = []
+            for query in request.queries:
+                results = search_fts_chunks(
+                    db_conn=conn,
+                    vector_index_name=index_name,
+                    queries=[query],
+                    top_k=request.top_k,
+                )
+                results_per_query.append(results)
 
-            return results
+            return results_per_query
 
     except ValueError as e:
         logger.error(f"Validation error in batch fulltext search: {str(e)}")

--- a/src/lex_db/api/routes.py
+++ b/src/lex_db/api/routes.py
@@ -8,8 +8,10 @@ from lex_db.embeddings import EmbeddingModel, TextType
 from lex_db.utils import get_logger
 import lex_db.database as db
 from lex_db.vector_store import (
+    RetrievalResult,
     VectorSearchResults,
     search_vector_index,
+    search_fts_chunks,
     get_all_vector_index_metadata,
     get_vector_index_metadata,
 )
@@ -47,7 +49,11 @@ class VectorSearchRequest(BaseModel):
 
 
 class HybridSearchRequest(BaseModel):
-    """Hybrid search request model."""
+    """Hybrid search request model.
+
+    .. deprecated::
+        Use batch semantic search and/or batch fulltext search endpoints instead.
+    """
 
     query_text: str
     top_k: int = 10
@@ -58,6 +64,20 @@ class HybridSearchRequest(BaseModel):
         advanced_search.SearchMethod.SEMANTIC,
         advanced_search.SearchMethod.FULLTEXT,
     ]
+
+
+class BatchVectorSearchRequest(BaseModel):
+    """Batch vector search request model."""
+
+    queries: list[tuple[str, TextType]]
+    top_k: int = 5
+
+
+class BatchFulltextSearchRequest(BaseModel):
+    """Batch fulltext search request model."""
+
+    queries: list[str]
+    top_k: int = 50
 
 
 @router.post(
@@ -97,9 +117,46 @@ async def vector_search(
 
 
 @router.post(
+    "/vector-search/indexes/{index_name}/batch",
+    operation_id="batch_vector_search",
+    summary="Batch search a vector index for similar content to multiple query texts",
+)
+async def batch_vector_search(
+    index_name: str, request: BatchVectorSearchRequest
+) -> list[VectorSearchResults]:
+    """Search a vector index for similar content to multiple query texts in batch."""
+    try:
+        with db.get_db_connection() as conn:
+            meta = get_vector_index_metadata(conn, index_name)
+            if not meta:
+                raise HTTPException(
+                    status_code=404, detail=f"Vector index '{index_name}' not found"
+                )
+            embedding_model = meta["embedding_model"]
+            logger.info(
+                f"Batch searching index '{index_name}' for {len(request.queries)} queries using model {embedding_model}"
+            )
+            results = search_vector_index(
+                db_conn=conn,
+                vector_index_name=index_name,
+                queries=request.queries,
+                embedding_model=embedding_model,
+                top_k=request.top_k,
+            )
+            return results
+    except ValueError as e:
+        logger.error(f"Validation error in batch vector search: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error in batch vector search: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Search error: {str(e)}")
+
+
+@router.post(
     "/hybrid-search/indexes/{index_name}/query",
     operation_id="hybrid_search",
-    summary="Hybrid search combining semantic and keyword search with RRF fusion",
+    summary="[DEPRECATED] Hybrid search combining semantic and keyword search with RRF fusion. Use batch semantic and/or batch fulltext search instead.",
+    deprecated=True,
 )
 async def hybrid_search(
     index_name: str, request: HybridSearchRequest
@@ -162,7 +219,8 @@ async def hybrid_search(
 @router.post(
     "/hyde-search/indexes/{index_name}/query",
     operation_id="hyde_search",
-    summary="HyDE search using LLM-generated hypothetical document",
+    summary="[DEPRECATED] HyDE search using LLM-generated hypothetical document. Use batch semantic search instead.",
+    deprecated=True,
 )
 async def hyde_search(
     index_name: str, request: VectorSearchRequest
@@ -196,6 +254,49 @@ async def hyde_search(
     except Exception as e:
         logger.error(f"Error in HyDE search: {str(e)}")
         raise HTTPException(status_code=500, detail=f"HyDE search error: {str(e)}")
+
+
+@router.post(
+    "/text-search/batch",
+    operation_id="batch_fulltext_search",
+    summary="Batch fulltext search across vector index chunks",
+)
+async def batch_fulltext_search(
+    request: BatchFulltextSearchRequest,
+    index_name: str = Query(
+        ..., description="Name of the vector index to search chunks in"
+    ),
+) -> list[RetrievalResult]:
+    """Perform batch fulltext search on vector index chunks using Danish FTS."""
+    try:
+        logger.info(
+            f"Batch fulltext search on '{index_name}' for {len(request.queries)} queries"
+        )
+        with db.get_db_connection() as conn:
+            # Verify vector index exists
+            meta = get_vector_index_metadata(conn, index_name)
+            if not meta:
+                raise HTTPException(
+                    status_code=404, detail=f"Vector index '{index_name}' not found"
+                )
+
+            results = search_fts_chunks(
+                db_conn=conn,
+                vector_index_name=index_name,
+                queries=request.queries,
+                top_k=request.top_k,
+            )
+
+            return results
+
+    except ValueError as e:
+        logger.error(f"Validation error in batch fulltext search: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error in batch fulltext search: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Batch fulltext search error: {str(e)}"
+        )
 
 
 @router.get(

--- a/src/lex_db/vector_store.py
+++ b/src/lex_db/vector_store.py
@@ -2,10 +2,11 @@
 
 from psycopg import Connection
 from psycopg import sql
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel
 from lex_db.utils import get_logger, split_document_into_chunks, ChunkingStrategy
+from lex_db.database import get_url_base
 from lex_db.embeddings import (
     EmbeddingModel,
     TextType,
@@ -382,6 +383,8 @@ class VectorSearchResult(BaseModel):
     chunk_seq: int
     chunk_text: str
     distance: float
+    url: Optional[str] = None
+    title: Optional[str] = None
 
 
 class VectorSearchResults(BaseModel):
@@ -409,17 +412,21 @@ def search_vector_index(
     results = []
     for query_vector in embeddings:
         # pgvector query using cosine distance operator (<=>)
-        # The query vector is passed twice because we use it in both SELECT and ORDER BY
+        # JOIN with articles table to get url and title for each result
         result = db_conn.execute(
             sql.SQL("""
                 SELECT 
-                    id,
-                    source_article_id,
-                    chunk_sequence_id,
-                    chunk_text,
-                    embedding <=> %s::vector AS distance
-                FROM {}
-                ORDER BY embedding <=> %s::vector
+                    vi.id,
+                    vi.source_article_id,
+                    vi.chunk_sequence_id,
+                    vi.chunk_text,
+                    vi.embedding <=> %s::vector AS distance,
+                    a.permalink,
+                    a.headword,
+                    a.encyclopedia_id
+                FROM {} vi
+                LEFT JOIN articles a ON vi.source_article_id = a.id
+                ORDER BY vi.embedding <=> %s::vector
                 LIMIT %s
             """).format(sql.Identifier(vector_index_name)),
             (query_vector, query_vector, top_k),
@@ -437,6 +444,12 @@ def search_vector_index(
                     chunk_seq=res["chunk_sequence_id"],  # type: ignore[call-overload]
                     chunk_text=res["chunk_text"],  # type: ignore[call-overload]
                     distance=res["distance"],  # type: ignore[call-overload]
+                    url=get_url_base(int(res["encyclopedia_id"])) + res["permalink"]  # type: ignore[call-overload]
+                    if res["encyclopedia_id"] and res["permalink"]
+                    else None,
+                    title=res["headword"]  # type: ignore[call-overload]
+                    if res["headword"]
+                    else None,
                 )
                 for res in query_result
             ]
@@ -454,6 +467,8 @@ class RetrievalResult(BaseModel):
     chunk_sequence: int
     chunk_text: str
     score: float
+    url: Optional[str] = None
+    title: Optional[str] = None
 
 
 def search_fts_chunks(

--- a/src/lex_db/vector_store.py
+++ b/src/lex_db/vector_store.py
@@ -385,6 +385,7 @@ class VectorSearchResult(BaseModel):
     distance: float
     url: Optional[str] = None
     title: Optional[str] = None
+    changed_at: Optional[str] = None
 
 
 class VectorSearchResults(BaseModel):
@@ -423,7 +424,8 @@ def search_vector_index(
                     vi.embedding <=> %s::vector AS distance,
                     a.permalink,
                     a.headword,
-                    a.encyclopedia_id
+                    a.encyclopedia_id,
+                    a.changed_at
                 FROM {} vi
                 LEFT JOIN articles a ON vi.source_article_id = a.id
                 ORDER BY vi.embedding <=> %s::vector
@@ -450,6 +452,9 @@ def search_vector_index(
                     title=res["headword"]  # type: ignore[call-overload]
                     if res["headword"]
                     else None,
+                    changed_at=res["changed_at"]  # type: ignore[call-overload]
+                    if res["changed_at"]
+                    else None,
                 )
                 for res in query_result
             ]
@@ -469,6 +474,7 @@ class RetrievalResult(BaseModel):
     score: float
     url: Optional[str] = None
     title: Optional[str] = None
+    changed_at: Optional[str] = None
 
 
 def search_fts_chunks(
@@ -515,7 +521,8 @@ def search_fts_chunks(
                     ts_rank(vi.chunk_text_tsv, plainto_tsquery('danish', %s)) AS score,
                     a.permalink,
                     a.headword,
-                    a.encyclopedia_id
+                    a.encyclopedia_id,
+                    a.changed_at
                 FROM {} vi
                 LEFT JOIN articles a ON vi.source_article_id = a.id
                 WHERE vi.chunk_text_tsv @@ plainto_tsquery('danish', %s)
@@ -538,6 +545,9 @@ def search_fts_chunks(
                     else None,
                     title=row["headword"]  # type: ignore[call-overload]
                     if row["headword"]
+                    else None,
+                    changed_at=row["changed_at"]  # type: ignore[call-overload]
+                    if row["changed_at"]
                     else None,
                 )
             )

--- a/src/lex_db/vector_store.py
+++ b/src/lex_db/vector_store.py
@@ -504,16 +504,21 @@ def search_fts_chunks(
 
         # Use plainto_tsquery for natural language queries
         # It handles tokenization and Danish stemming automatically
+        # JOIN with articles table to get url and title for each result
         result = db_conn.execute(
             sql.SQL("""
                 SELECT
-                    id,
-                    source_article_id,
-                    chunk_sequence_id,
-                    chunk_text,
-                    ts_rank(chunk_text_tsv, plainto_tsquery('danish', %s)) AS score
-                FROM {}
-                WHERE chunk_text_tsv @@ plainto_tsquery('danish', %s)
+                    vi.id,
+                    vi.source_article_id,
+                    vi.chunk_sequence_id,
+                    vi.chunk_text,
+                    ts_rank(vi.chunk_text_tsv, plainto_tsquery('danish', %s)) AS score,
+                    a.permalink,
+                    a.headword,
+                    a.encyclopedia_id
+                FROM {} vi
+                LEFT JOIN articles a ON vi.source_article_id = a.id
+                WHERE vi.chunk_text_tsv @@ plainto_tsquery('danish', %s)
                 ORDER BY score DESC
                 LIMIT %s
             """).format(sql.Identifier(vector_index_name)),
@@ -528,6 +533,12 @@ def search_fts_chunks(
                     chunk_sequence=row["chunk_sequence_id"],  # type: ignore[call-overload]
                     chunk_text=row["chunk_text"],  # type: ignore[call-overload]
                     score=row["score"],  # type: ignore[call-overload]
+                    url=get_url_base(int(row["encyclopedia_id"])) + row["permalink"]  # type: ignore[call-overload]
+                    if row["encyclopedia_id"] and row["permalink"]
+                    else None,
+                    title=row["headword"]  # type: ignore[call-overload]
+                    if row["headword"]
+                    else None,
                 )
             )
 

--- a/src/lex_db/vector_store.py
+++ b/src/lex_db/vector_store.py
@@ -1,5 +1,7 @@
 """Vector store operations for Lex DB."""
 
+from datetime import datetime
+
 from psycopg import Connection
 from psycopg import sql
 from typing import Any, Optional
@@ -385,7 +387,7 @@ class VectorSearchResult(BaseModel):
     distance: float
     url: Optional[str] = None
     title: Optional[str] = None
-    changed_at: Optional[str] = None
+    changed_at: Optional[datetime] = None
 
 
 class VectorSearchResults(BaseModel):
@@ -474,7 +476,7 @@ class RetrievalResult(BaseModel):
     score: float
     url: Optional[str] = None
     title: Optional[str] = None
-    changed_at: Optional[str] = None
+    changed_at: Optional[datetime] = None
 
 
 def search_fts_chunks(

--- a/src/tests/test_vector_store.py
+++ b/src/tests/test_vector_store.py
@@ -323,6 +323,9 @@ class TestSearchVectorIndex:
                 "chunk_sequence_id": 0,
                 "chunk_text": "Test chunk",
                 "distance": 0.15,
+                "encyclopedia_id": 1,
+                "permalink": "test-article",
+                "headword": "Test Article",
             }
         ]
         mock_db_connection.execute.return_value.fetchall.return_value = search_rows
@@ -343,6 +346,8 @@ class TestSearchVectorIndex:
         assert results[0].results[0].source_article_id == "123"
         assert results[0].results[0].chunk_text == "Test chunk"
         assert results[0].results[0].distance == 0.15
+        assert results[0].results[0].url == "https://denstoredanske.lex.dk/test-article"
+        assert results[0].results[0].title == "Test Article"
 
     @patch("lex_db.vector_store.generate_embeddings")
     def test_search_no_results(

--- a/src/tests/test_vector_store.py
+++ b/src/tests/test_vector_store.py
@@ -1,5 +1,7 @@
 """Unit tests for vector_store module."""
 
+from datetime import datetime
+
 import pytest
 from unittest.mock import MagicMock, patch
 from lex_db.vector_store import (
@@ -349,7 +351,7 @@ class TestSearchVectorIndex:
         assert results[0].results[0].distance == 0.15
         assert results[0].results[0].url == "https://denstoredanske.lex.dk/test-article"
         assert results[0].results[0].title == "Test Article"
-        assert results[0].results[0].changed_at == "2024-01-01"
+        assert results[0].results[0].changed_at == datetime.fromisoformat("2024-01-01")
 
     @patch("lex_db.vector_store.generate_embeddings")
     def test_search_no_results(

--- a/src/tests/test_vector_store.py
+++ b/src/tests/test_vector_store.py
@@ -326,6 +326,7 @@ class TestSearchVectorIndex:
                 "encyclopedia_id": 1,
                 "permalink": "test-article",
                 "headword": "Test Article",
+                "changed_at": "2024-01-01",
             }
         ]
         mock_db_connection.execute.return_value.fetchall.return_value = search_rows
@@ -348,6 +349,7 @@ class TestSearchVectorIndex:
         assert results[0].results[0].distance == 0.15
         assert results[0].results[0].url == "https://denstoredanske.lex.dk/test-article"
         assert results[0].results[0].title == "Test Article"
+        assert results[0].results[0].changed_at == "2024-01-01"
 
     @patch("lex_db.vector_store.generate_embeddings")
     def test_search_no_results(


### PR DESCRIPTION
I want to push the hybrid and hyde search functionality to the orchestrator, so I've added batch search endpoints here to make the calls more efficient.

Fixes #92 
Fixes #90 